### PR TITLE
fix: point Pi at a top-level extension entrypoint

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,11 +23,11 @@ npm run smoke:runtime      # scripts/smoke/runtime-worker.ts — real pi rpc wor
 npm run smoke:team         # scripts/smoke/team-flow.ts — TeamManager end-to-end
 ```
 
-Single test file: `tsx --test tests/runtime/worker-manager.test.ts`. Load the extension locally: `pi -e ./extensions/pi-agent-team/index.ts`.
+Single test file: `tsx --test tests/runtime/worker-manager.test.ts`. Load the extension locally: `pi -e ./extensions/index.ts`.
 
 ## Architecture at a glance
 
-Top-down: `extensions/pi-agent-team/index.ts` (entrypoint — tools, commands, UI wiring) → `src/control-plane/team-manager.ts` (single coordination boundary) → `src/runtime/` (worker process + RPC + event normalizer + worker manager) → supporting layers (`src/comms/`, `src/profiles/`, `src/safety/`, `src/prompts/`, `src/ui/`, `src/commands/`).
+Top-down: `extensions/index.ts` (package entrypoint, thin re-export) → `extensions/pi-agent-team/index.ts` (implementation entrypoint — tools, commands, UI wiring) → `src/control-plane/team-manager.ts` (single coordination boundary) → `src/runtime/` (worker process + RPC + event normalizer + worker manager) → supporting layers (`src/comms/`, `src/profiles/`, `src/safety/`, `src/prompts/`, `src/ui/`, `src/commands/`).
 
 Commands are thin wrappers over `TeamManager` methods and never touch `WorkerManager` directly.
 

--- a/extensions/index.ts
+++ b/extensions/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./pi-agent-team/index";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-agents-team",
-  "version": "2026.04.22",
+  "version": "2026.4.23",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-agents-team",
-      "version": "2026.04.22",
+      "version": "2026.4.23",
       "license": "MIT",
       "devDependencies": {
         "@mariozechner/pi-coding-agent": "^0.69.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-agents-team",
-  "version": "2026.04.22",
+  "version": "2026.4.23",
   "private": true,
   "description": "Pi package that turns the main session into an orchestrator for RPC-backed worker agents.",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "pi": {
     "extensions": [
-      "./extensions/pi-agent-team/index.ts"
+      "./extensions/index.ts"
     ]
   },
   "peerDependencies": {


### PR DESCRIPTION
## Summary
Point Pi at a top-level extension entrypoint so the package loads through `extensions/index.ts` instead of the deeper implementation path. This shortens the startup label Pi derives from the extension path while keeping the existing implementation structure intact.

## Changes
- add `extensions/index.ts` as a thin re-export of `extensions/pi-agent-team/index.ts`
- update `package.json` so the Pi manifest points at `./extensions/index.ts`
- update `CLAUDE.md` to reference the new package entrypoint
- bump the package version from `2026.04.22` to `2026.4.23`
- refresh `package-lock.json` to match the version bump