### PR TITLE
Enable cost display in full team-init scaffold

### DIFF
--- a/src/commands/team-init.ts
+++ b/src/commands/team-init.ts
@@ -70,6 +70,9 @@ function buildFullScaffold(): TeamProjectConfigFile {
 		workerAccess: {
 			allowPathsOutsideProject: true,
 		},
+		display: {
+			cost: true,
+		},
 		roles,
 	};
 }

--- a/tests/commands/team-init.test.ts
+++ b/tests/commands/team-init.test.ts
@@ -53,6 +53,7 @@ test("buildFullScaffold pre-populates every builtin profile in the schema v4 sha
 	assert.equal(scaffold.enabled, true);
 	assert.equal(scaffold.routingMode, "team");
 	assert.equal(scaffold.workerAccess?.allowPathsOutsideProject, true);
+	assert.equal(scaffold.display?.cost, true);
 	const roles = scaffold.roles ?? {};
 	for (const profile of DEFAULT_TEAM_CONFIG.profiles) {
 		const role = (roles as Record<string, unknown>)[profile.name] as any;
@@ -100,6 +101,7 @@ test("/team-init local writes a full scaffold inside the project", async () => {
 	assert.equal(parsed.enabled, true);
 	assert.equal(parsed.routingMode, "team");
 	assert.equal(parsed.workerAccess.allowPathsOutsideProject, true);
+	assert.equal(parsed.display.cost, true);
 	const roleNames = Object.keys(parsed.roles ?? {}).sort();
 	assert.deepEqual(roleNames, DEFAULT_TEAM_CONFIG.profiles.map((profile) => profile.name).sort());
 	assert.ok(emitted[0]?.includes(expectedPath));


### PR DESCRIPTION
## Feature Description

Enable the full `/team-init` scaffold to opt into cost display explicitly, matching the extension default that surfaces agent cost totals in the widget and Cost tab.

## User Story

As a Pi Agents Team user generating a full project scaffold, I want the scaffolded config to include the cost display setting so the generated file reflects the expected default behavior.

## Type of Change

- [x] New feature

## Implementation Details

The full scaffold builder now writes `display.cost: true` alongside the existing `enabled`, `routingMode`, `workerAccess`, and role settings. The command tests assert the in-memory scaffold and the written local scaffold both include the cost display flag.

### Architecture

This fits in the existing project-config scaffold path for `/team-init`; no runtime worker behavior or public command surface changes are introduced.

### Key Files Changed

| File | Change |
|------|--------|
| `src/commands/team-init.ts` | Adds `display.cost: true` to the full scaffold config. |
| `tests/commands/team-init.test.ts` | Verifies both full scaffold construction and local file writes include the cost flag. |

## API Changes

No API changes.

## Database Changes

- [x] No database changes
- [ ] Migration included and tested

## How to Test

Not completed locally. Attempted:

```bash
tsx --test tests/commands/team-init.test.ts
```

but `tsx` was not available in the current shell (`command not found`). After dependencies are installed, run:

```bash
npm run check
```

## Edge Cases Considered

- Full scaffold construction includes the cost setting before writing files.
- Local `/team-init` output preserves the cost setting in the generated config.

## Checklist

- [ ] Code follows the project's style guidelines
- [ ] Self-reviewed the code
- [x] Added unit tests for new functionality
- [ ] Added integration tests where applicable
- [ ] Existing tests pass locally
- [ ] Updated documentation
- [ ] Tested on mobile (if UI change)
- [ ] No new warnings or console errors introduced
- [x] Backwards compatible (or migration plan documented)

## Feature Flag

- [x] No feature flag needed
- [ ] Behind feature flag: `FLAG_NAME`

## Related Issues

None found in branch name or commit messages.

## Screenshots / Demo

Not applicable.

## Deployment Notes

No special deployment notes.
