### PR TITLE
fix: resolve worker spawn ENOENT on Windows

### DIFF
--- a/src/control-plane/team-manager.ts
+++ b/src/control-plane/team-manager.ts
@@ -267,6 +267,8 @@ export class TeamManager {
 			// the task prompt's requested-skill instructions are impossible to
 			// satisfy.
 			allowSkills: task.skills !== undefined && task.skills.length > 0,
+			command: this.config.rpc.command,
+			baseArgs: this.config.rpc.args,
 		});
 
 		this.registry.upsertWorker(worker.state);

--- a/src/runtime/worker-process.ts
+++ b/src/runtime/worker-process.ts
@@ -107,10 +107,16 @@ export function buildWorkerProcessArgs(options: WorkerProcessOptions): string[] 
 export function spawnWorkerProcess(options: WorkerProcessOptions): WorkerProcessHandle {
 	const command = options.command ?? "pi";
 	const args = buildWorkerProcessArgs(options);
+	const isWindows = process.platform === "win32";
 	const child = spawn(command, args, {
 		cwd: options.cwd,
 		env: options.env,
 		stdio: ["pipe", "pipe", "pipe"],
+		// On Windows the `pi` CLI is installed as a `.cmd` batch wrapper.
+		// Node's spawn without shell:true cannot resolve .cmd files via
+		// PATH/PATHEXT, resulting in ENOENT. Enable shell so the OS handles
+		// command resolution on Windows; no-op on other platforms.
+		...(isWindows ? { shell: true } : {}),
 	}) as ChildProcessWithoutNullStreams;
 
 	return new NodeWorkerProcessHandle(child as unknown as WorkerTransport);


### PR DESCRIPTION
## Summary

Fixes #23 — worker agents crash with `spawn pi ENOENT` on Windows, making the extension completely unusable on that platform.

## Changes

### `src/runtime/worker-process.ts`
Add `shell: true` to `spawn()` options on Windows (`process.platform === "win32"`). On Windows, npm installs the `pi` CLI as a `.cmd` batch wrapper — Node's `spawn` without `shell: true` cannot resolve `.cmd` files via PATH/PATHEXT.

### `src/control-plane/team-manager.ts`
Forward `this.config.rpc.command` and `this.config.rpc.args` to `WorkerManager.launchWorker()`. These config fields were defined in the schema and defaulted but never passed through at the call site.

## Testing

- [x] Worker spawns successfully on Windows after both patches
- [x] `config.rpc` values flow through to the spawn call
- [ ] Non-Windows platforms — no behavioral change expected (shell option only applies on win32)

## Impact

- **Windows users:** Extension goes from completely broken to fully functional
- **Unix/macOS users:** No change — `shell: true` is only added on win32, and the config plumbing fix is transparent since defaults match the previous fallback behavior