### PR TITLE
Ship compiled ESM package with Pi preflight

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 node_modules/
 coverage/
-dist/
+/dist/
 .pi/
 .trekoon/
 .DS_Store

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,20 +7,23 @@ Pi extension. Visible session = orchestrator; background workers run through `pi
 ```bash
 npm install
 npm run typecheck       # tsc --noEmit
-npm test                # tsx --test tests/**/*.test.ts
+npm test                # tsx --test root and nested test files
 npm run check           # typecheck + tests
+npm run build           # compile JS + declarations and copy package assets to dist/
+npm run build:publish   # same publish build, invoked by prepack
 npm run smoke:runtime   # tsx scripts/smoke/runtime-worker.ts
 npm run smoke:team      # tsx scripts/smoke/team-flow.ts
 ```
 
-Single test: `npx tsx --test tests/runtime/worker-manager.test.ts`; avoid `npm test -- <path>` because the script already has a glob. Local load: `pi -e ./extensions/index.ts`. Node `>=22.19.0`. Strict TS, ESM, `node:test` + `node:assert/strict`; no jest/vitest/bun. No lint/build scripts. Package ships TS; `prepublishOnly` runs `npm run check`.
+Single test: `npx tsx --test tests/runtime/worker-manager.test.ts`; avoid `npm test -- <path>` because the script already has globs. Local load: `pi -e ./extensions/index.ts` through `jiti`. Node `>=22.19.0`. Strict TS, ESM, `node:test` + `node:assert/strict`; no jest/vitest/bun. The npm package ships native ESM JavaScript plus `.d.ts` declarations. `prepack` runs `npm run build:publish`; `prepublishOnly` runs `npm run check`.
 
 ## Project map
 
 | Path | Purpose |
 |---|---|
-| `extensions/index.ts` | package export |
+| `extensions/index.ts` | local-development shim and source package entrypoint |
 | `extensions/pi-agent-team/index.ts` | tools, commands, lifecycle/session handlers, widget/overlay wiring |
+| `dist/` | ignored generated npm output: compiled JS, declarations, prompts, and profiles |
 | `src/control-plane/team-manager.ts` | coordination boundary; commands/tools go here, not to `WorkerManager` |
 | `src/control-plane/task-registry.ts`, `persistence.ts` | registry, persisted state, retained pruned usage |
 | `src/runtime/` | RPC launch/process, JSONL events, `WorkerManager`, final-answer extraction, buffers |
@@ -28,7 +31,7 @@ Single test: `npx tsx --test tests/runtime/worker-manager.test.ts`; avoid `npm t
 | `src/commands/`, `src/comms/`, `src/prompts/`, `src/profiles/`, `src/project-config/`, `src/safety/` | focused subsystems |
 | `docs/architecture.md`, `docs/operations.md`, `docs/profiles.md`, `docs/prompting.md` | deep refs |
 
-`profiles/*.md` and `prompts/agents/*.md` are parity-tested; rename/update together. `package.json` exports `./extensions/index.ts`; Pi discovers the same path via `pi.extensions`.
+`profiles/*.md` and `prompts/agents/*.md` are parity-tested; rename/update together. For installed consumers, both the package export and `pi.extensions` target `./dist/extensions/index.js`; the package export exposes declarations at `./dist/extensions/index.d.ts`. `scripts/build-publish.mjs` rebuilds ignored `dist/` and copies `prompts/` and `profiles/` into it. Do not commit generated output.
 
 ## Operator surface
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,23 +20,23 @@ pi -e ./extensions/index.ts
 pi -e ./extensions/index.ts -p "/team"   # open straight into the dashboard
 ```
 
-If you want to install the local checkout as a real Pi package instead:
-
-```bash
-pi install /absolute/path/to/pi-agents-team
-```
+This is the local-development path. Pi loads `extensions/index.ts` through `jiti`; installed consumers use the compiled npm package instead. Direct Git package installs are not supported because `dist/` is ignored and Pi's Git install flow does not build it.
 
 ## Commands
 
 ```bash
 npm run typecheck        # tsc --noEmit
-npm test                 # tsx --test tests/**/*.test.ts (node:test runner, node:assert/strict)
+npm test                 # tsx --test root and nested tests (node:test runner, node:assert/strict)
 npm run check            # typecheck + test, one shot
+npm run build            # compile the publishable package into dist/
+npm run build:publish    # same publish build, used by prepack
 npm run smoke:runtime    # spawns a real pi RPC worker
 npm run smoke:team       # exercises TeamManager end-to-end
 ```
 
 Run a single test file with `tsx --test tests/runtime/worker-manager.test.ts`.
+
+Both build commands run `scripts/build-publish.mjs`. The script clears `dist/`, compiles source files to native ESM JavaScript plus `.d.ts` declarations, and copies `prompts/` and `profiles/` into the output. `npm pack` and `npm publish` run `prepack`, which calls `npm run build:publish`; publishing also runs `prepublishOnly` (`npm run check`). Keep `dist/` ignored because it is generated for packaging, not maintained as source.
 
 ## Test discipline
 
@@ -56,8 +56,10 @@ Unit tests lean on `MockWorkerTransport` / `MockWorkerHandle` in `tests/runtime/
 ## Package layout
 
 ```text
-extensions/index.ts                 # package-facing extension entrypoint
-extensions/pi-agent-team/index.ts   # internal implementation entrypoint, tool + command registration, UI wiring
+extensions/index.ts                 # local-development shim and source package entrypoint
+extensions/pi-agent-team/index.ts   # source implementation entrypoint, registration, and UI wiring
+dist/extensions/index.js            # generated npm/Pi entrypoint (native ESM)
+dist/**/*.d.ts                      # generated TypeScript declarations
 src/runtime/                         # worker process, RPC client, event normalizer, worker manager
 src/control-plane/                   # team manager, task registry, persistence snapshots
 src/comms/                           # steer/follow-up routing, passive ping, summary parser, relay extractor

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Pi main session acts as the coordinator, while background RPC workers execute th
 
 ## Install
 
-Install from npm:
+Install the published package from npm:
 
 ```bash
 pi install npm:pi-agents-team
@@ -24,41 +24,20 @@ pi install npm:pi-agents-team
 pi -e npm:pi-agents-team
 ```
 
-You can also install from Git using one of the options below.
+The npm package ships native ESM JavaScript and TypeScript declarations. Its package export and Pi extension entry both resolve to `dist/extensions/index.js`; the packaged prompts and profiles also live under `dist/`. Direct Git package installs are not supported because `dist/` is ignored in the repository and Pi's Git install flow does not build it.
 
-### Option 1: Git via `pi install`
+### Run a local checkout
+
+Use the TypeScript entrypoint when developing from source:
 
 ```bash
-# SSH (the git: prefix is required for git@host:path shorthand)
-pi install git:git@github.com:KristjanPikhof/pi-agents-team
-
-# HTTPS (prefix optional for protocol URLs)
-pi install https://github.com/KristjanPikhof/pi-agents-team
+git clone git@github.com:KristjanPikhof/pi-agents-team.git
+cd pi-agents-team
+npm install
+pi -e ./extensions/index.ts
 ```
 
-### Option 2: Edit settings.json by hand
-
-Add an entry to the `packages` array. Pi installs any missing packages the next time a session starts.
-
-**Global**, in `~/.pi/agent/settings.json`:
-
-```json
-{
-  "packages": [
-    "git:git@github.com:KristjanPikhof/pi-agents-team"
-  ]
-}
-```
-
-**Project-local**, in `.pi/settings.json` (shared with your team via git):
-
-```json
-{
-  "packages": [
-    "git:git@github.com:KristjanPikhof/pi-agents-team"
-  ]
-}
-```
+Pi loads this local-development shim through `jiti`, so a build is not required before each run. Use `npm run build` when you need to inspect or validate the compiled package output in `dist/`.
 
 ## Operator commands
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -23,8 +23,8 @@ User
   ↓
 Main Pi session (orchestrator)
   ↓
-Package entrypoint (extensions/index.ts)
-  │   └─ delegates to internal implementation entrypoint (extensions/pi-agent-team/index.ts)
+Package entrypoint (dist/extensions/index.js for npm; extensions/index.ts for local development)
+  │   └─ delegates to the matching compiled/source internal implementation entrypoint
   ├─ Control plane
   │   ├─ TeamManager            (coordinates delegation, snapshots, waits)
   │   ├─ TaskRegistry           (active workers + task metadata)
@@ -98,6 +98,12 @@ After launch-setting checks, reuse refreshes worker stats and rejects saturated 
 While the worker runs, RPC events flow through the event normalizer into `applyNormalizedEvent`, which mutates the worker's `WorkerRuntimeState` (status, textBuffer, lastToolName, usage, requested/effective thinking levels, lastSummary, pendingRelayQuestions, finalAnswer) and emits a snapshot. `TeamManager` upserts the snapshot into the registry and re-emits `state_change`, which drives both persistence and UI listeners.
 
 ## Key decisions
+
+### Installed packages use compiled output
+
+The supported installed distribution is the npm package. Its package export and Pi extension entry both target `dist/extensions/index.js`, with declarations at `dist/extensions/index.d.ts`. The publish build also copies `prompts/` and `profiles/` under `dist/`, preserving the runtime-relative asset layout.
+
+Local development takes a separate path: `pi -e ./extensions/index.ts` loads the source shim through `jiti`. `npm run build` and `npm run build:publish` both regenerate `dist/`; `prepack` invokes `build:publish` before npm creates the package. Generated `dist/` remains ignored because it is a packaging artifact, which is also why direct Git package installation is unsupported.
 
 ### Pi RPC is the worker transport
 

--- a/extensions/index.ts
+++ b/extensions/index.ts
@@ -1,1 +1,1 @@
-export { default } from "./pi-agent-team/index";
+export { default } from "./pi-agent-team/index.js";

--- a/extensions/pi-agent-team/index.ts
+++ b/extensions/pi-agent-team/index.ts
@@ -22,6 +22,7 @@ import { formatRelayToast, formatWorkerLabel, formatWorkerStartedToast, formatWo
 import { formatAgentMessageResult, formatDelegateTaskResult, formatWaitForAgentsResult, formatWorkerCompact, formatWorkers } from "../../src/ui/tool-formatters.js";
 import { renderAgentToolCallTitle } from "../../src/ui/tool-renderers.js";
 import type { NormalizedWorkerEvent } from "../../src/runtime/event-normalizer.js";
+import type { WorkerPiVersionMismatchEvent } from "../../src/runtime/worker-manager.js";
 import { THINKING_LEVELS, type LoadedTeamProjectConfig, type PersistedTeamState, type TeamConfig, type ThinkingLevel, type ThinkingLevelConfigWarning, type WorkerRuntimeState } from "../../src/types.js";
 
 const DelegateTaskSchema = Type.Object({
@@ -274,7 +275,12 @@ function buildThinkingClampToast(event: Extract<NormalizedWorkerEvent, { type: "
 	return `Pi Agents Team: worker ${event.workerId} (${event.profileName}) requested thinkingLevel ${event.requested}; Pi clamped to ${event.effective}${modelPart} because the model lacks support. Edit agents-team.json or change model.`;
 }
 
+function buildPiVersionMismatchToast(event: WorkerPiVersionMismatchEvent): string {
+	return event.message;
+}
+
 export const _testing = {
+	buildPiVersionMismatchToast,
 	buildThinkingClampToast,
 	buildThinkingLevelWarningToast,
 	getOrchestratorThinkingLevel,
@@ -324,6 +330,7 @@ export default function (pi: ExtensionAPI): void {
 	const toastedScaffoldStale = getProcessStableScaffoldFreshnessToasts();
 	const toastedThinkingLevelWarnings = new Map<string, true>();
 	const toastedThinkingClamps = new Map<string, true>();
+	let toastedPiVersionMismatch = false;
 	const lastStatus = new Map<string, WorkerRuntimeState["status"]>();
 	const lastRelayCount = new Map<string, number>();
 	const pendingStartedTransitions: Array<{ workerId: string; profileName: string }> = [];
@@ -472,6 +479,12 @@ export default function (pi: ExtensionAPI): void {
 		activeContext.ui.notify(buildThinkingClampToast(event), "warning");
 	}
 
+	function notifyPiVersionMismatch(event: WorkerPiVersionMismatchEvent): void {
+		if (!activeContext?.hasUI || toastedPiVersionMismatch) return;
+		toastedPiVersionMismatch = true;
+		activeContext.ui.notify(buildPiVersionMismatchToast(event), "warning");
+	}
+
 	function attachTeamManagerListener(manager: TeamManager): void {
 		detachTeamManagerListener();
 		resetUiTracking();
@@ -524,6 +537,7 @@ export default function (pi: ExtensionAPI): void {
 		const workerEvents = (manager as unknown as {
 			workerManager?: {
 				onEvent(listener: (_worker: unknown, event: NormalizedWorkerEvent) => void): () => void;
+				onPiVersionMismatch(listener: (event: WorkerPiVersionMismatchEvent) => void): () => void;
 			};
 		}).workerManager;
 		const detachWorkerEventListener = workerEvents?.onEvent((_worker, event) => {
@@ -531,9 +545,11 @@ export default function (pi: ExtensionAPI): void {
 				notifyThinkingClamp(event);
 			}
 		}) ?? (() => {});
+		const detachVersionMismatchListener = workerEvents?.onPiVersionMismatch(notifyPiVersionMismatch) ?? (() => {});
 		detachTeamManagerListener = () => {
 			detachStateListener();
 			detachWorkerEventListener();
+			detachVersionMismatchListener();
 		};
 	}
 
@@ -765,6 +781,7 @@ export default function (pi: ExtensionAPI): void {
 	pi.on("session_start", async (event, ctx) => {
 		stopTipRotation();
 		activeContext = ctx;
+		toastedPiVersionMismatch = false;
 		reloading = true;
 		try {
 			activeProjectConfig = loadActiveTeamConfig({

--- a/extensions/pi-agent-team/index.ts
+++ b/extensions/pi-agent-team/index.ts
@@ -1,28 +1,28 @@
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { Type } from "typebox";
-import { CURRENT_SCAFFOLD_VERSION, DEFAULT_TEAM_CONFIG, createDefaultTeamState } from "../../src/config";
+import { CURRENT_SCAFFOLD_VERSION, DEFAULT_TEAM_CONFIG, createDefaultTeamState } from "../../src/config.js";
 import {
 	createPersistedStateSnapshot,
 	markRestoredWorkersExited,
 	restorePersistedTeamState,
-} from "../../src/control-plane/persistence";
-import { buildOrchestratorPromptBundle } from "../../src/prompts/contracts";
-import { TeamManager, isTerminalWorkerStatus } from "../../src/control-plane/team-manager";
-import { loadActiveTeamConfig } from "../../src/project-config/loader";
-import { registerCopyCommand } from "../../src/commands/copy";
-import { registerTeamCommand } from "../../src/commands/team";
-import { registerTeamEnableCommand } from "../../src/commands/team-enable";
-import { registerTeamInitCommand } from "../../src/commands/team-init";
-import { registerTeamResultCommand } from "../../src/commands/team-result";
-import { registerTeamSteerCommand } from "../../src/commands/team-steer";
-import { registerTeamStopCommand } from "../../src/commands/team-stop";
-import { registerTeamAutocomplete } from "../../src/ui/autocomplete";
-import { buildTeamStatusLine, buildTeamWidgetLines, getTeamStatusTip, hasAnimatedWorkers } from "../../src/ui/status-widget";
-import { formatRelayToast, formatWorkerLabel, formatWorkerStartedToast, formatWorkerTerminalToast, formatWorkersStartedToast, formatWorkersTerminalToast } from "../../src/ui/display-grammar";
-import { formatAgentMessageResult, formatDelegateTaskResult, formatWaitForAgentsResult, formatWorkerCompact, formatWorkers } from "../../src/ui/tool-formatters";
-import { renderAgentToolCallTitle } from "../../src/ui/tool-renderers";
-import type { NormalizedWorkerEvent } from "../../src/runtime/event-normalizer";
-import { THINKING_LEVELS, type LoadedTeamProjectConfig, type PersistedTeamState, type TeamConfig, type ThinkingLevel, type ThinkingLevelConfigWarning, type WorkerRuntimeState } from "../../src/types";
+} from "../../src/control-plane/persistence.js";
+import { buildOrchestratorPromptBundle } from "../../src/prompts/contracts.js";
+import { TeamManager, isTerminalWorkerStatus } from "../../src/control-plane/team-manager.js";
+import { loadActiveTeamConfig } from "../../src/project-config/loader.js";
+import { registerCopyCommand } from "../../src/commands/copy.js";
+import { registerTeamCommand } from "../../src/commands/team.js";
+import { registerTeamEnableCommand } from "../../src/commands/team-enable.js";
+import { registerTeamInitCommand } from "../../src/commands/team-init.js";
+import { registerTeamResultCommand } from "../../src/commands/team-result.js";
+import { registerTeamSteerCommand } from "../../src/commands/team-steer.js";
+import { registerTeamStopCommand } from "../../src/commands/team-stop.js";
+import { registerTeamAutocomplete } from "../../src/ui/autocomplete.js";
+import { buildTeamStatusLine, buildTeamWidgetLines, getTeamStatusTip, hasAnimatedWorkers } from "../../src/ui/status-widget.js";
+import { formatRelayToast, formatWorkerLabel, formatWorkerStartedToast, formatWorkerTerminalToast, formatWorkersStartedToast, formatWorkersTerminalToast } from "../../src/ui/display-grammar.js";
+import { formatAgentMessageResult, formatDelegateTaskResult, formatWaitForAgentsResult, formatWorkerCompact, formatWorkers } from "../../src/ui/tool-formatters.js";
+import { renderAgentToolCallTitle } from "../../src/ui/tool-renderers.js";
+import type { NormalizedWorkerEvent } from "../../src/runtime/event-normalizer.js";
+import { THINKING_LEVELS, type LoadedTeamProjectConfig, type PersistedTeamState, type TeamConfig, type ThinkingLevel, type ThinkingLevelConfigWarning, type WorkerRuntimeState } from "../../src/types.js";
 
 const DelegateTaskSchema = Type.Object({
 	title: Type.String({ description: "Short title for the delegated task" }),

--- a/extensions/pi-agent-team/index.ts
+++ b/extensions/pi-agent-team/index.ts
@@ -279,8 +279,26 @@ function buildPiVersionMismatchToast(event: WorkerPiVersionMismatchEvent): strin
 	return event.message;
 }
 
+function createPiVersionMismatchNotifier(notify: (message: string) => void): {
+	notify(event: WorkerPiVersionMismatchEvent): void;
+	reset(): void;
+} {
+	let warned = false;
+	return {
+		notify(event) {
+			if (warned) return;
+			warned = true;
+			notify(buildPiVersionMismatchToast(event));
+		},
+		reset() {
+			warned = false;
+		},
+	};
+}
+
 export const _testing = {
 	buildPiVersionMismatchToast,
+	createPiVersionMismatchNotifier,
 	buildThinkingClampToast,
 	buildThinkingLevelWarningToast,
 	getOrchestratorThinkingLevel,
@@ -330,7 +348,9 @@ export default function (pi: ExtensionAPI): void {
 	const toastedScaffoldStale = getProcessStableScaffoldFreshnessToasts();
 	const toastedThinkingLevelWarnings = new Map<string, true>();
 	const toastedThinkingClamps = new Map<string, true>();
-	let toastedPiVersionMismatch = false;
+	const piVersionMismatchNotifier = createPiVersionMismatchNotifier((message) => {
+		if (activeContext?.hasUI) activeContext.ui.notify(message, "warning");
+	});
 	const lastStatus = new Map<string, WorkerRuntimeState["status"]>();
 	const lastRelayCount = new Map<string, number>();
 	const pendingStartedTransitions: Array<{ workerId: string; profileName: string }> = [];
@@ -480,9 +500,8 @@ export default function (pi: ExtensionAPI): void {
 	}
 
 	function notifyPiVersionMismatch(event: WorkerPiVersionMismatchEvent): void {
-		if (!activeContext?.hasUI || toastedPiVersionMismatch) return;
-		toastedPiVersionMismatch = true;
-		activeContext.ui.notify(buildPiVersionMismatchToast(event), "warning");
+		if (!activeContext?.hasUI) return;
+		piVersionMismatchNotifier.notify(event);
 	}
 
 	function attachTeamManagerListener(manager: TeamManager): void {
@@ -781,7 +800,7 @@ export default function (pi: ExtensionAPI): void {
 	pi.on("session_start", async (event, ctx) => {
 		stopTipRotation();
 		activeContext = ctx;
-		toastedPiVersionMismatch = false;
+		piVersionMismatchNotifier.reset();
 		reloading = true;
 		try {
 			activeProjectConfig = loadActiveTeamConfig({

--- a/package-lock.json
+++ b/package-lock.json
@@ -560,7 +560,7 @@
         "typebox": "1.1.38"
       },
       "bin": {
-        "pi-ai": "dist/cli.js"
+        "pi-ai": "./dist/cli.js"
       },
       "engines": {
         "node": ">=22.19.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,8 +13,8 @@
         "typebox": "^1.0.56"
       },
       "devDependencies": {
-        "@earendil-works/pi-coding-agent": "^0.79.2",
-        "@earendil-works/pi-tui": "^0.79.2",
+        "@earendil-works/pi-coding-agent": "0.80.6",
+        "@earendil-works/pi-tui": "0.80.6",
         "@types/node": "^25.6.0",
         "tsx": "^4.22.4",
         "typescript": "^6.0.3"
@@ -23,21 +23,21 @@
         "node": ">=22.19.0"
       },
       "peerDependencies": {
-        "@earendil-works/pi-coding-agent": ">=0.79.2",
-        "@earendil-works/pi-tui": ">=0.79.0"
+        "@earendil-works/pi-coding-agent": ">=0.80.6",
+        "@earendil-works/pi-tui": ">=0.80.6"
       }
     },
     "node_modules/@earendil-works/pi-coding-agent": {
-      "version": "0.79.2",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.79.2.tgz",
-      "integrity": "sha512-RAB5NvI3qw3E991iigPfeE5lqUTmsDGwlqmpqDlCqBDYNCJFJXuCJfNhyBe6/kAI1seYIheHYu5BA0q8adUqgA==",
+      "version": "0.80.6",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.80.6.tgz",
+      "integrity": "sha512-vcfD6tOk402isLl3Cm/qbn2O10TvgroMp1+/fEGM24ZdvETFCdOYv5VZ7m59EI5fPsjfSJh+CpQ5bhBrhfOg7g==",
       "dev": true,
       "hasShrinkwrap": true,
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-agent-core": "^0.79.2",
-        "@earendil-works/pi-ai": "^0.79.2",
-        "@earendil-works/pi-tui": "^0.79.2",
+        "@earendil-works/pi-agent-core": "^0.80.6",
+        "@earendil-works/pi-ai": "^0.80.6",
+        "@earendil-works/pi-tui": "^0.80.6",
         "@silvia-odwyer/photon-node": "0.3.4",
         "chalk": "5.6.2",
         "cross-spawn": "7.0.6",
@@ -49,8 +49,9 @@
         "jiti": "2.7.0",
         "minimatch": "10.2.5",
         "proper-lockfile": "4.1.2",
+        "semver": "7.8.0",
         "typebox": "1.1.38",
-        "undici": "8.3.0",
+        "undici": "8.5.0",
         "yaml": "2.9.0"
       },
       "bin": {
@@ -526,12 +527,12 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-agent-core": {
-      "version": "0.79.2",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.79.2.tgz",
+      "version": "0.80.6",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.80.6.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-ai": "^0.79.2",
+        "@earendil-works/pi-ai": "^0.80.6",
         "ignore": "7.0.5",
         "typebox": "1.1.38",
         "yaml": "2.9.0"
@@ -541,15 +542,16 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-ai": {
-      "version": "0.79.2",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.79.2.tgz",
+      "version": "0.80.6",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.80.6.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "0.91.1",
         "@aws-sdk/client-bedrock-runtime": "3.1048.0",
         "@google/genai": "1.52.0",
-        "@mistralai/mistralai": "2.2.1",
+        "@mistralai/mistralai": "2.2.6",
+        "@opentelemetry/api": "1.9.0",
         "@smithy/node-http-handler": "4.7.3",
         "http-proxy-agent": "7.0.2",
         "https-proxy-agent": "7.0.6",
@@ -558,20 +560,20 @@
         "typebox": "1.1.38"
       },
       "bin": {
-        "pi-ai": "./dist/cli.js"
+        "pi-ai": "dist/cli.js"
       },
       "engines": {
         "node": ">=22.19.0"
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-tui": {
-      "version": "0.79.2",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.79.2.tgz",
+      "version": "0.80.6",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.80.6.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "get-east-asian-width": "1.6.0",
-        "marked": "15.0.12"
+        "marked": "18.0.5"
       },
       "engines": {
         "node": ">=22.19.0"
@@ -808,15 +810,24 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@mistralai/mistralai": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@mistralai/mistralai/-/mistralai-2.2.1.tgz",
-      "integrity": "sha512-uKU8CZmL2RzYKmplsU01hii4p3pe4HqJefpWNRWXm1Tcm0Sm4xXfwSLIy4k7ZCPlbETCGcp69E7hZs+WOJ5itQ==",
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/@mistralai/mistralai/-/mistralai-2.2.6.tgz",
+      "integrity": "sha512-W8pX7zHxjJvMIpw8JMxeJEleapXX0Q9NPszdNzqkM3MIEoIGPObdodujj+WHteXEvGfaP/AMwlNyRfEzSY6dQQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.40.0",
         "ws": "^8.18.0",
         "zod": "^3.25.0 || ^4.0.0",
         "zod-to-json-schema": "^3.25.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.9.0"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        }
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@nodable/entities": {
@@ -831,6 +842,26 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@opentelemetry/api": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.41.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.41.1.tgz",
+      "integrity": "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
@@ -854,9 +885,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/eventemitter": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
       "dev": true,
       "license": "BSD-3-Clause"
     },
@@ -874,13 +905,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
       "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
-      "dev": true,
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/inquire": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.2.tgz",
-      "integrity": "sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==",
       "dev": true,
       "license": "BSD-3-Clause"
     },
@@ -1527,16 +1551,16 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/marked": {
-      "version": "15.0.12",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-15.0.12.tgz",
-      "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
+      "version": "18.0.5",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.5.tgz",
+      "integrity": "sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w==",
       "dev": true,
       "license": "MIT",
       "bin": {
         "marked": "bin/marked.js"
       },
       "engines": {
-        "node": ">= 18"
+        "node": ">= 20"
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/minimatch": {
@@ -1728,9 +1752,9 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/protobufjs": {
-      "version": "7.5.9",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.9.tgz",
-      "integrity": "sha512-Od4muIm3HW1AouyHF5lONOf1FWo3hY1NbFDoy191X9GzhpgW1clCoaFjfVs2rKJNFYpTNJbje4cbAIDBZJ63ZA==",
+      "version": "7.6.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.4.tgz",
+      "integrity": "sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
@@ -1738,15 +1762,14 @@
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
         "@protobufjs/codegen": "^2.0.5",
-        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/eventemitter": "^1.1.1",
         "@protobufjs/fetch": "^1.1.1",
         "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.2",
         "@protobufjs/path": "^1.1.2",
         "@protobufjs/pool": "^1.1.0",
         "@protobufjs/utf8": "^1.1.1",
         "@types/node": ">=13.7.0",
-        "long": "^5.0.0"
+        "long": "^5.3.2"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -1782,6 +1805,19 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/semver": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/shebang-command": {
       "version": "2.0.0",
@@ -1848,9 +1884,9 @@
       "license": "MIT"
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/undici": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-8.3.0.tgz",
-      "integrity": "sha512-TkUDgb6tl7KOGZ+7e8E3d2FYgUQgF6z5YypqjWmixVQSQERFcVrVg0ySADm2LVLRh5ljAaHTCR5Fmz3Q34rB7Q==",
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.5.0.tgz",
+      "integrity": "sha512-xamtWoB1EshgjpmlXd7GGm2VfdDtw1+rD8uhry8pSNW3If6S8E0m2T2+orSKeZXEn/aPJMviCpDBA65WJt8zhg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1891,9 +1927,9 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/ws": {
-      "version": "8.20.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
-      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1965,14 +2001,14 @@
       }
     },
     "node_modules/@earendil-works/pi-tui": {
-      "version": "0.79.2",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.79.2.tgz",
-      "integrity": "sha512-RGPWBacWh3HpMqkYg0tyiQWpFDZUmAikI4GoYXXWS0+MKljeD2t0VT5kdrP6fe05OD2jFbMlryau9ZHZwzkw6w==",
+      "version": "0.80.6",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.80.6.tgz",
+      "integrity": "sha512-bSuzS4EVSqEPj/Qr/p9eqCESfKsGuDNbl77EGci8Iaqqt/C/XCBZL1MjXaxSWW1NsT5afjp/Cb0NTPzOLv/aPA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "get-east-asian-width": "1.6.0",
-        "marked": "15.0.12"
+        "marked": "18.0.5"
       },
       "engines": {
         "node": ">=22.19.0"
@@ -2516,16 +2552,16 @@
       "license": "ISC"
     },
     "node_modules/marked": {
-      "version": "15.0.12",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-15.0.12.tgz",
-      "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
+      "version": "18.0.5",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.5.tgz",
+      "integrity": "sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w==",
       "dev": true,
       "license": "MIT",
       "bin": {
         "marked": "bin/marked.js"
       },
       "engines": {
-        "node": ">= 18"
+        "node": ">= 20"
       }
     },
     "node_modules/path-key": {

--- a/package.json
+++ b/package.json
@@ -31,15 +31,15 @@
   "bugs": {
     "url": "https://github.com/KristjanPikhof/pi-agents-team/issues"
   },
-  "main": "./extensions/index.ts",
+  "main": "./dist/extensions/index.js",
   "exports": {
-    ".": "./extensions/index.ts"
+    ".": {
+      "types": "./dist/extensions/index.d.ts",
+      "default": "./dist/extensions/index.js"
+    }
   },
   "files": [
-    "extensions/",
-    "src/",
-    "prompts/",
-    "profiles/",
+    "dist",
     "README.md",
     "LICENSE"
   ],
@@ -51,15 +51,18 @@
   },
   "scripts": {
     "typecheck": "tsc --noEmit",
-    "test": "tsx --test tests/**/*.test.ts",
+    "test": "tsx --test tests/*.test.ts tests/**/*.test.ts",
     "check": "npm run typecheck && npm test",
+    "build": "node scripts/build-publish.mjs",
+    "build:publish": "node scripts/build-publish.mjs",
+    "prepack": "npm run build:publish",
     "prepublishOnly": "npm run check",
     "smoke:runtime": "tsx scripts/smoke/runtime-worker.ts",
     "smoke:team": "tsx scripts/smoke/team-flow.ts"
   },
   "pi": {
     "extensions": [
-      "./extensions/index.ts"
+      "./dist/extensions/index.js"
     ],
     "prompts": []
   },

--- a/package.json
+++ b/package.json
@@ -71,12 +71,12 @@
     "typebox": "^1.0.56"
   },
   "peerDependencies": {
-    "@earendil-works/pi-coding-agent": ">=0.79.2",
-    "@earendil-works/pi-tui": ">=0.79.0"
+    "@earendil-works/pi-coding-agent": ">=0.80.6",
+    "@earendil-works/pi-tui": ">=0.80.6"
   },
   "devDependencies": {
-    "@earendil-works/pi-coding-agent": "^0.79.2",
-    "@earendil-works/pi-tui": "^0.79.2",
+    "@earendil-works/pi-coding-agent": "0.80.6",
+    "@earendil-works/pi-tui": "0.80.6",
     "@types/node": "^25.6.0",
     "tsx": "^4.22.4",
     "typescript": "^6.0.3"

--- a/scripts/build-publish.mjs
+++ b/scripts/build-publish.mjs
@@ -1,0 +1,50 @@
+import { spawnSync } from "node:child_process";
+import { copyFile, mkdir, readdir, rm } from "node:fs/promises";
+import { createRequire } from "node:module";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const projectRoot = dirname(dirname(fileURLToPath(import.meta.url)));
+const distDir = join(projectRoot, "dist");
+const require = createRequire(import.meta.url);
+const tscPath = require.resolve("typescript/bin/tsc");
+
+async function copyTree(sourceDir, destinationDir) {
+  await mkdir(destinationDir, { recursive: true });
+
+  const entries = await readdir(sourceDir, { withFileTypes: true });
+  entries.sort((left, right) =>
+    left.name < right.name ? -1 : left.name > right.name ? 1 : 0,
+  );
+
+  for (const entry of entries) {
+    const source = join(sourceDir, entry.name);
+    const destination = join(destinationDir, entry.name);
+
+    if (entry.isDirectory()) {
+      await copyTree(source, destination);
+    } else if (entry.isFile()) {
+      await copyFile(source, destination);
+    } else {
+      throw new Error(`Unsupported asset entry: ${source}`);
+    }
+  }
+}
+
+await rm(distDir, { recursive: true, force: true });
+
+const compilation = spawnSync(
+  process.execPath,
+  [tscPath, "-p", join(projectRoot, "tsconfig.publish.json")],
+  { cwd: projectRoot, stdio: "inherit" },
+);
+
+if (compilation.error) {
+  throw compilation.error;
+}
+if (compilation.status !== 0) {
+  process.exit(compilation.status ?? 1);
+}
+
+await copyTree(join(projectRoot, "prompts"), join(distDir, "prompts"));
+await copyTree(join(projectRoot, "profiles"), join(distDir, "profiles"));

--- a/src/commands/copy.ts
+++ b/src/commands/copy.ts
@@ -1,9 +1,9 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
-import { buildCopyPayload } from "../ui/copy-payload";
-import { formatCommandWarning } from "../ui/display-grammar";
-import { copyToClipboard } from "../util/clipboard";
-import { formatUnknownWorker, suggestTargets } from "../util/suggest";
-import type { CommandRegistrationContext } from "./team";
+import { buildCopyPayload } from "../ui/copy-payload.js";
+import { formatCommandWarning } from "../ui/display-grammar.js";
+import { copyToClipboard } from "../util/clipboard.js";
+import { formatUnknownWorker, suggestTargets } from "../util/suggest.js";
+import type { CommandRegistrationContext } from "./team.js";
 
 export function registerCopyCommand(pi: ExtensionAPI, dependencies: CommandRegistrationContext): void {
 	pi.registerCommand("team-copy", {

--- a/src/commands/team-enable.ts
+++ b/src/commands/team-enable.ts
@@ -2,13 +2,13 @@ import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-a
 import { existsSync, mkdirSync, readFileSync } from "node:fs";
 import { dirname } from "node:path";
 import { Value } from "typebox/value";
-import { TeamProjectConfigSchema } from "../config";
-import { findNearestProjectConfigPath, getProjectConfigPathForScope } from "../project-config/loader";
-import { formatCommandWarning } from "../ui/display-grammar";
-import type { LoadedTeamProjectConfig } from "../types";
-import { TEAM_PROJECT_SCHEMA_VERSION } from "../types";
-import { atomicWriteFileSync } from "../util/backup";
-import type { RoutingMode, TeamManager } from "../control-plane/team-manager";
+import { TeamProjectConfigSchema } from "../config.js";
+import { findNearestProjectConfigPath, getProjectConfigPathForScope } from "../project-config/loader.js";
+import { formatCommandWarning } from "../ui/display-grammar.js";
+import type { LoadedTeamProjectConfig } from "../types.js";
+import { TEAM_PROJECT_SCHEMA_VERSION } from "../types.js";
+import { atomicWriteFileSync } from "../util/backup.js";
+import type { RoutingMode, TeamManager } from "../control-plane/team-manager.js";
 
 export interface TeamEnableCommandDependencies {
 	getTeamManager: () => TeamManager;

--- a/src/commands/team-init.ts
+++ b/src/commands/team-init.ts
@@ -1,10 +1,10 @@
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { existsSync, mkdirSync } from "node:fs";
 import { dirname } from "node:path";
-import { atomicWriteFileSync, backupExisting, formatBackupTimestamp } from "../util/backup";
-import { CURRENT_SCAFFOLD_VERSION, DEFAULT_TEAM_CONFIG } from "../config";
-import { formatCommandWarning } from "../ui/display-grammar";
-import { getProjectConfigPathForScope } from "../project-config/loader";
+import { atomicWriteFileSync, backupExisting, formatBackupTimestamp } from "../util/backup.js";
+import { CURRENT_SCAFFOLD_VERSION, DEFAULT_TEAM_CONFIG } from "../config.js";
+import { formatCommandWarning } from "../ui/display-grammar.js";
+import { getProjectConfigPathForScope } from "../project-config/loader.js";
 import {
 	DEFAULT_MODEL_SENTINEL,
 	DEFAULT_PROMPT_SENTINEL,
@@ -14,7 +14,7 @@ import {
 	type TeamConfigScope,
 	type TeamProfileSpec,
 	type TeamProjectConfigFile,
-} from "../types";
+} from "../types.js";
 
 interface InitCommandDependencies {
 	emitText: (ctx: ExtensionContext, text: string) => void;

--- a/src/commands/team-init.ts
+++ b/src/commands/team-init.ts
@@ -9,6 +9,7 @@ import {
 	DEFAULT_MODEL_SENTINEL,
 	DEFAULT_PROMPT_SENTINEL,
 	TEAM_PROJECT_SCHEMA_VERSION,
+	THINKING_LEVELS,
 	type PartialRawProjectRoleConfigMap,
 	type ProjectRoleFlatConfig,
 	type TeamConfigScope,
@@ -139,7 +140,7 @@ export function registerTeamInitCommand(pi: ExtensionAPI, dependencies: InitComm
 			lines.push(
 				`Wrote ${scope} agents-team.json scaffold (schemaVersion ${TEAM_PROJECT_SCHEMA_VERSION}, scaffoldVersion ${CURRENT_SCAFFOLD_VERSION}) to ${targetPath}.`,
 				"Global worker access policy lives under `workerAccess`. Set `allowPathsOutsideProject: false` to restrict delegated worker path scopes to the project root/current cwd.",
-				`Per-role knobs: whenToUse (a trigger sentence, "Use when...", shown to the orchestrator so it picks the right role), model (${DEFAULT_MODEL_SENTINEL} = inherit orchestrator, or "provider/model-id"), thinkingLevel (optional; inherits orchestrator level when omitted; valid values: off, minimal, low, medium, high, xhigh; Pi may clamp unsupported levels), access (tools, write, pathScope, extensionMode, extensions for explicit Pi provider/model extension sources), prompt (${DEFAULT_PROMPT_SENTINEL} = built-in, or a path to your own .md, or the prompt text inline).`,
+				`Per-role knobs: whenToUse (a trigger sentence, "Use when...", shown to the orchestrator so it picks the right role), model (${DEFAULT_MODEL_SENTINEL} = inherit orchestrator, or "provider/model-id"), thinkingLevel (optional; inherits orchestrator level when omitted; valid values: ${THINKING_LEVELS.join(", ")}; Pi may clamp unsupported levels), access (tools, write, pathScope, extensionMode, extensions for explicit Pi provider/model extension sources), prompt (${DEFAULT_PROMPT_SENTINEL} = built-in, or a path to your own .md, or the prompt text inline).`,
 				"Rename, remove, or add roles freely — the orchestrator sees exactly what you declare. Delete a role block to fall back to the built-in defaults for that name.",
 				"Run /reload to apply changes in this session.",
 			);

--- a/src/commands/team-result.ts
+++ b/src/commands/team-result.ts
@@ -1,8 +1,8 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
-import { formatCommandWarning } from "../ui/display-grammar";
-import { formatWorkerDetail as formatSharedWorkerDetail } from "../ui/tool-formatters";
-import { formatUnknownWorker, suggestTargets } from "../util/suggest";
-import type { CommandRegistrationContext } from "./team";
+import { formatCommandWarning } from "../ui/display-grammar.js";
+import { formatWorkerDetail as formatSharedWorkerDetail } from "../ui/tool-formatters.js";
+import { formatUnknownWorker, suggestTargets } from "../util/suggest.js";
+import type { CommandRegistrationContext } from "./team.js";
 
 function stripFinalAnswerBlocks(transcript?: string): string | undefined {
 	const sanitized = transcript?.replace(/<final_answer>[\s\S]*?<\/final_answer>/gi, "").trim();

--- a/src/commands/team-steer.ts
+++ b/src/commands/team-steer.ts
@@ -1,8 +1,8 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
-import type { AgentMessageResult } from "../control-plane/team-manager";
-import { formatCommandWarning } from "../ui/display-grammar";
-import { formatUnknownWorker, suggestTargets } from "../util/suggest";
-import type { CommandRegistrationContext } from "./team";
+import type { AgentMessageResult } from "../control-plane/team-manager.js";
+import { formatCommandWarning } from "../ui/display-grammar.js";
+import { formatUnknownWorker, suggestTargets } from "../util/suggest.js";
+import type { CommandRegistrationContext } from "./team.js";
 
 interface ParsedArgs {
 	target?: string;

--- a/src/commands/team-stop.ts
+++ b/src/commands/team-stop.ts
@@ -1,8 +1,8 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
-import type { WorkerRuntimeState, WorkerStatus } from "../types";
-import { formatCommandWarning } from "../ui/display-grammar";
-import { formatUnknownWorker, suggestTargets } from "../util/suggest";
-import type { CommandRegistrationContext } from "./team";
+import type { WorkerRuntimeState, WorkerStatus } from "../types.js";
+import { formatCommandWarning } from "../ui/display-grammar.js";
+import { formatUnknownWorker, suggestTargets } from "../util/suggest.js";
+import type { CommandRegistrationContext } from "./team.js";
 
 const UNREACHABLE_TERMINAL: ReadonlySet<WorkerStatus> = new Set<WorkerStatus>([
 	"completed",

--- a/src/commands/team.ts
+++ b/src/commands/team.ts
@@ -1,9 +1,9 @@
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
-import { openTeamDashboardOverlay } from "../ui/overlay";
-import { buildTeamDashboardText } from "../ui/dashboard";
-import { formatCommandWarning } from "../ui/display-grammar";
-import type { TeamManager } from "../control-plane/team-manager";
-import { formatUnknownWorker, suggestTargets } from "../util/suggest";
+import { openTeamDashboardOverlay } from "../ui/overlay.js";
+import { buildTeamDashboardText } from "../ui/dashboard.js";
+import { formatCommandWarning } from "../ui/display-grammar.js";
+import type { TeamManager } from "../control-plane/team-manager.js";
+import { formatUnknownWorker, suggestTargets } from "../util/suggest.js";
 
 export interface CommandRegistrationContext {
 	teamManager: TeamManager;

--- a/src/comms/agent-messaging.ts
+++ b/src/comms/agent-messaging.ts
@@ -1,4 +1,4 @@
-import type { WorkerStatus } from "../types";
+import type { WorkerStatus } from "../types.js";
 
 export type WorkerMessageDeliveryInput = "auto" | "steer" | "follow_up";
 export type WorkerMessageDeliveryResolved = "steer" | "follow_up" | "prompt";

--- a/src/comms/ping.ts
+++ b/src/comms/ping.ts
@@ -1,5 +1,5 @@
-import type { RelayQuestion, WorkerRuntimeState } from "../types";
-import { formatContextBudget } from "../ui/usage-format";
+import type { RelayQuestion, WorkerRuntimeState } from "../types.js";
+import { formatContextBudget } from "../ui/usage-format.js";
 
 export interface WorkerPingSnapshot {
 	workerId: string;

--- a/src/comms/relay-queue.ts
+++ b/src/comms/relay-queue.ts
@@ -1,4 +1,4 @@
-import type { RelayQuestion, WorkerRuntimeState } from "../types";
+import type { RelayQuestion, WorkerRuntimeState } from "../types.js";
 
 export function collectPendingRelayQuestions(activeWorkers: Record<string, WorkerRuntimeState>): RelayQuestion[] {
 	return Object.values(activeWorkers)

--- a/src/comms/summary.ts
+++ b/src/comms/summary.ts
@@ -1,4 +1,4 @@
-import type { RelayQuestion, WorkerRuntimeState, WorkerSummary } from "../types";
+import type { RelayQuestion, WorkerRuntimeState, WorkerSummary } from "../types.js";
 
 function trimLine(line: string): string {
 	return line.replace(/^[-*]\s*/, "").trim();

--- a/src/config.ts
+++ b/src/config.ts
@@ -18,8 +18,8 @@ import {
 	type TeamConfig,
 	type TeamDashboardEntry,
 	type WorkerRuntimeState,
-} from "./types";
-import { createZeroWorkerUsageAggregate, normalizeWorkerUsageAggregate } from "./usage";
+} from "./types.js";
+import { createZeroWorkerUsageAggregate, normalizeWorkerUsageAggregate } from "./usage.js";
 
 // Re-export so consumers (/team-init, loader) can import from config.ts alongside DEFAULT_TEAM_CONFIG.
 export { TEAM_SCAFFOLD_VERSION };

--- a/src/control-plane/persistence.ts
+++ b/src/control-plane/persistence.ts
@@ -1,5 +1,5 @@
-import { createDefaultTeamState, normalizePersistedTeamState } from "../config";
-import type { PersistedTeamState } from "../types";
+import { createDefaultTeamState, normalizePersistedTeamState } from "../config.js";
+import type { PersistedTeamState } from "../types.js";
 
 interface SessionLikeEntry {
 	type: string;

--- a/src/control-plane/task-registry.ts
+++ b/src/control-plane/task-registry.ts
@@ -1,7 +1,7 @@
-import { buildDashboardEntries, createDefaultTeamState, normalizePersistedTeamState } from "../config";
-import { collectPendingRelayQuestions } from "../comms/relay-queue";
-import { compareWorkerIds, type DelegatedTaskInput, type PersistedTeamState, type WorkerRuntimeState, type WorkerUsageAggregate } from "../types";
-import { addWorkerUsageToAggregate } from "../usage";
+import { buildDashboardEntries, createDefaultTeamState, normalizePersistedTeamState } from "../config.js";
+import { collectPendingRelayQuestions } from "../comms/relay-queue.js";
+import { compareWorkerIds, type DelegatedTaskInput, type PersistedTeamState, type WorkerRuntimeState, type WorkerUsageAggregate } from "../types.js";
+import { addWorkerUsageToAggregate } from "../usage.js";
 
 export class TaskRegistry {
 	private state: PersistedTeamState;

--- a/src/control-plane/team-manager.ts
+++ b/src/control-plane/team-manager.ts
@@ -1,13 +1,13 @@
 import { EventEmitter } from "node:events";
-import { DEFAULT_TEAM_CONFIG } from "../config";
-import { TaskRegistry } from "./task-registry";
-import { resolveWorkerMessageDelivery, type WorkerMessageDeliveryResolved } from "../comms/agent-messaging";
-import { buildPassivePing } from "../comms/ping";
-import { buildWorkerTaskPrompt } from "../prompts/contracts";
-import { WorkerManager, type AssistantChunk, type ManagedWorkerRecord, type WorkerActivityEvent, type WorkerConsoleEvent } from "../runtime/worker-manager";
-import { applyLaunchPolicy } from "../safety/launch-policy";
-import { isPathWithinProjectRoot } from "../safety/path-scope";
-import { aggregateWorkerUsage } from "../usage";
+import { DEFAULT_TEAM_CONFIG } from "../config.js";
+import { TaskRegistry } from "./task-registry.js";
+import { resolveWorkerMessageDelivery, type WorkerMessageDeliveryResolved } from "../comms/agent-messaging.js";
+import { buildPassivePing } from "../comms/ping.js";
+import { buildWorkerTaskPrompt } from "../prompts/contracts.js";
+import { WorkerManager, type AssistantChunk, type ManagedWorkerRecord, type WorkerActivityEvent, type WorkerConsoleEvent } from "../runtime/worker-manager.js";
+import { applyLaunchPolicy } from "../safety/launch-policy.js";
+import { isPathWithinProjectRoot } from "../safety/path-scope.js";
+import { aggregateWorkerUsage } from "../usage.js";
 import type {
 	DelegatedTaskInput,
 	PersistedTeamState,
@@ -19,7 +19,7 @@ import type {
 	WorkerRuntimeState,
 	WorkerStatus,
 	WorkerUsageAggregate,
-} from "../types";
+} from "../types.js";
 
 const TERMINAL_STATUSES: ReadonlySet<WorkerStatus> = new Set<WorkerStatus>([
 	"idle",

--- a/src/profiles/default-profiles.ts
+++ b/src/profiles/default-profiles.ts
@@ -1,5 +1,5 @@
-import { DEFAULT_TEAM_CONFIG } from "../config";
-import type { TeamProfileSpec } from "../types";
+import { DEFAULT_TEAM_CONFIG } from "../config.js";
+import type { TeamProfileSpec } from "../types.js";
 
 export const DEFAULT_PROFILE_SPECS: TeamProfileSpec[] = DEFAULT_TEAM_CONFIG.profiles.map((profile) => ({ ...profile }));
 

--- a/src/profiles/loader.ts
+++ b/src/profiles/loader.ts
@@ -2,8 +2,8 @@ import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { parseFrontmatter } from "@earendil-works/pi-coding-agent";
-import { getDefaultProfile, DEFAULT_PROFILE_SPECS } from "./default-profiles";
-import type { TeamProfileSpec, ThinkingLevel, WorkerExtensionMode, WorkerWritePolicy } from "../types";
+import { getDefaultProfile, DEFAULT_PROFILE_SPECS } from "./default-profiles.js";
+import type { TeamProfileSpec, ThinkingLevel, WorkerExtensionMode, WorkerWritePolicy } from "../types.js";
 
 interface ProfileFrontmatter {
 	name?: string;

--- a/src/project-config/loader.ts
+++ b/src/project-config/loader.ts
@@ -1,9 +1,8 @@
 import { existsSync, readFileSync, realpathSync, statSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, isAbsolute, resolve, relative } from "node:path";
-import { fileURLToPath } from "node:url";
 import { Value } from "typebox/value";
-import { CURRENT_SCAFFOLD_VERSION, DEFAULT_TEAM_CONFIG, TeamProjectConfigSchema } from "../config";
+import { CURRENT_SCAFFOLD_VERSION, DEFAULT_TEAM_CONFIG, TeamProjectConfigSchema } from "../config.js";
 import {
 	DEFAULT_MODEL_SENTINEL,
 	DEFAULT_PROMPT_SENTINEL,
@@ -33,7 +32,8 @@ import {
 	type TeamProjectConfigLayer,
 	type ThinkingLevelConfigWarning,
 	type WorkerWritePolicy,
-} from "../types";
+} from "../types.js";
+import { isRecursiveOrchestratorExtensionSource } from "../safety/self-extension.js";
 
 function clonePathScope(pathScope: TeamPathScope | undefined): TeamPathScope | undefined {
 	if (!pathScope) return undefined;
@@ -142,77 +142,12 @@ function realpathOrSelf(path: string): string {
 	}
 }
 
-const SELF_EXTENSION_PACKAGE_NAME = "pi-agents-team";
-const SELF_EXTENSION_ENTRYPOINTS = [
-	"extensions/index.ts",
-	"extensions/pi-agent-team/index.ts",
-] as const;
-const SELF_EXTENSION_PACKAGE_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
-const SELF_EXTENSION_PATHS: ReadonlySet<string> = new Set(
-	SELF_EXTENSION_ENTRYPOINTS.flatMap((entrypoint) => {
-		const path = resolve(SELF_EXTENSION_PACKAGE_ROOT, entrypoint);
-		const realPath = realpathOrSelf(path);
-		return realPath === path ? [path] : [path, realPath];
-	}),
-);
-
-function isSelfPackageExtensionSource(source: string): boolean {
-	const spec = source.startsWith("npm:") ? source.slice("npm:".length) : source;
-	const escapedName = SELF_EXTENSION_PACKAGE_NAME.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-	if (new RegExp(`^${escapedName}(?:@[^/]+)?(?:/|$)`).test(spec)) return true;
-	return getExtensionSourceTail(source) === SELF_EXTENSION_PACKAGE_NAME;
-}
-
-function getExtensionSourceTail(source: string): string | undefined {
-	let spec = source.trim();
-	if (spec.startsWith("npm:")) spec = spec.slice("npm:".length);
-	if (spec.startsWith("git+")) spec = spec.slice("git+".length);
-	if (spec.startsWith("git:")) spec = spec.slice("git:".length);
-	try {
-		const url = new URL(spec);
-		spec = url.pathname;
-	} catch {
-		const scpLikeMatch = /^[^@/\s]+@[^:\s]+:(.+)$/.exec(spec);
-		if (scpLikeMatch?.[1]) spec = scpLikeMatch[1];
-	}
-	spec = spec.split(/[?#]/, 1)[0] ?? spec;
-	const tail = spec.split(/[\\/]/).filter((part) => part.length > 0).at(-1);
-	return tail?.replace(/\.git$/i, "").replace(/@[^@/]+$/, "");
-}
-
-function isPathLikeExtensionSource(source: string): boolean {
-	if (isAbsolute(source) || /^[a-zA-Z]:[\\/]/.test(source)) return true;
-	if (source === "." || source === ".." || source.startsWith("./") || source.startsWith("../")) return true;
-	if (source === "extensions") return true;
-	if (source.startsWith("npm:") || source.startsWith("git:") || source.startsWith("http://") || source.startsWith("https://")) return false;
-	if (source.startsWith("@")) return false;
-	return /[\\/]/.test(source);
-}
-
 function isLocalExtensionPathSource(source: string): boolean {
 	if (isAbsolute(source) || /^[a-zA-Z]:[\\/]/.test(source)) return false;
 	if (source.startsWith("npm:") || source.startsWith("git:") || source.startsWith("git+")) return false;
 	if (source.startsWith("http://") || source.startsWith("https://")) return false;
 	if (source.startsWith("@")) return false;
 	return source === "." || source === ".." || source === "extensions" || source.startsWith("./") || source.startsWith("../") || /[\\/]/.test(source);
-}
-
-function isSameOrAncestorPath(candidate: string, target: string): boolean {
-	const rel = relative(candidate, target);
-	return rel === "" || (rel.length > 0 && !rel.startsWith("..") && !isAbsolute(rel));
-}
-
-function isRecursiveOrchestratorExtensionSource(source: string, baseDir: string): boolean {
-	const trimmed = source.trim();
-	if (trimmed.length === 0) return false;
-	if (isSelfPackageExtensionSource(trimmed)) return true;
-	if (!isPathLikeExtensionSource(trimmed)) return false;
-
-	const resolved = isAbsolute(trimmed) ? trimmed : resolve(baseDir, trimmed);
-	const realResolved = realpathOrSelf(resolved);
-	return [...SELF_EXTENSION_PATHS].some(
-		(selfPath) => isSameOrAncestorPath(resolved, selfPath) || isSameOrAncestorPath(realResolved, selfPath),
-	);
 }
 
 interface ResolvedPath {

--- a/src/prompts/contracts.ts
+++ b/src/prompts/contracts.ts
@@ -1,10 +1,10 @@
 import { existsSync, readFileSync } from "node:fs";
 import { dirname, isAbsolute, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import { DEFAULT_TEAM_CONFIG, buildOrchestratorSystemPrompt } from "../config";
-import type { RoutingMode } from "../control-plane/team-manager";
-import { GENERIC_WORKER_PROMPT_SENTINEL } from "../project-config/loader";
-import type { DelegatedTaskInput, PersistedTeamState, TeamConfig, TeamProfileSpec } from "../types";
+import { DEFAULT_TEAM_CONFIG, buildOrchestratorSystemPrompt } from "../config.js";
+import type { RoutingMode } from "../control-plane/team-manager.js";
+import { GENERIC_WORKER_PROMPT_SENTINEL } from "../project-config/loader.js";
+import type { DelegatedTaskInput, PersistedTeamState, TeamConfig, TeamProfileSpec } from "../types.js";
 
 const moduleDir = dirname(fileURLToPath(import.meta.url));
 const promptsRoot = resolve(moduleDir, "../../prompts");

--- a/src/runtime/event-normalizer.ts
+++ b/src/runtime/event-normalizer.ts
@@ -1,5 +1,5 @@
-import type { RpcEvent, RpcSessionState } from "./rpc-client";
-import type { ThinkingLevel } from "../types";
+import type { RpcEvent, RpcSessionState } from "./rpc-client.js";
+import type { ThinkingLevel } from "../types.js";
 
 export interface WorkerStartedEvent {
 	type: "worker_started";

--- a/src/runtime/pi-version.ts
+++ b/src/runtime/pi-version.ts
@@ -123,7 +123,7 @@ export async function probeWorkerPiVersion(
 			result = { stdout: "", stderr: "", code: null, error: error instanceof Error ? error : new Error(String(error)) };
 		}
 		if (result.error || result.code !== 0) {
-			const detail = result.error?.message ?? result.stderr.trim() || `exit code ${result.code}`;
+			const detail = result.error?.message ?? (result.stderr.trim() || `exit code ${result.code}`);
 			return {
 				...common,
 				supported: false,

--- a/src/runtime/pi-version.ts
+++ b/src/runtime/pi-version.ts
@@ -1,0 +1,162 @@
+import { spawn as nodeSpawn } from "node:child_process";
+import { createRequire } from "node:module";
+import { basename, resolve } from "node:path";
+import { VERSION } from "@earendil-works/pi-coding-agent";
+
+const require = createRequire(import.meta.url);
+const crossSpawn = require("cross-spawn") as typeof nodeSpawn;
+
+export const HOST_PI_VERSION = VERSION;
+export const MINIMUM_WORKER_PI_VERSION = "0.80.6";
+
+export interface ParsedPiVersion {
+	major: number;
+	minor: number;
+	patch: number;
+	text: string;
+}
+
+export interface PiVersionCommandResult {
+	stdout: string;
+	stderr: string;
+	code: number | null;
+	error?: Error;
+}
+
+export type RunPiVersionCommand = (input: {
+	command: string;
+	args: string[];
+	cwd: string;
+	env?: NodeJS.ProcessEnv;
+}) => Promise<PiVersionCommandResult>;
+
+export interface PiVersionProbeOptions {
+	command?: string;
+	baseArgs?: string[];
+	cwd: string;
+	env?: NodeJS.ProcessEnv;
+}
+
+export interface PiVersionProbeResult {
+	command: string;
+	versionArgs: string[];
+	hostVersion: string;
+	minimumVersion: string;
+	workerVersion?: string;
+	supported: boolean;
+	mismatch: boolean;
+	message?: string;
+}
+
+export type ProbeWorkerPiVersion = (options: PiVersionProbeOptions) => Promise<PiVersionProbeResult>;
+
+const probeCache = new Map<string, Promise<PiVersionProbeResult>>();
+
+export function parsePiVersion(output: string): ParsedPiVersion | undefined {
+	const match = output.trim().match(/^(?:pi(?:\s+version)?\s+)?v?(\d+)\.(\d+)\.(\d+)(?:[-+][0-9A-Za-z.-]+)?$/i);
+	if (!match) return undefined;
+	return {
+		major: Number(match[1]),
+		minor: Number(match[2]),
+		patch: Number(match[3]),
+		text: `${Number(match[1])}.${Number(match[2])}.${Number(match[3])}`,
+	};
+}
+
+export function comparePiVersions(left: ParsedPiVersion, right: ParsedPiVersion): number {
+	return left.major - right.major || left.minor - right.minor || left.patch - right.patch;
+}
+
+function versionPrefix(baseArgs: string[] | undefined): string[] {
+	if (!baseArgs) return [];
+	const prefix: string[] = [];
+	for (const arg of baseArgs) {
+		if (arg.startsWith("-")) break;
+		prefix.push(arg);
+	}
+	return prefix;
+}
+
+function commandCacheKey(command: string, args: string[]): string {
+	const resolvedCommand = command.includes("/") || command.includes("\\") ? resolve(command) : command;
+	return `${resolvedCommand}\0${args.join("\0")}`;
+}
+
+export const runPiVersionCommand: RunPiVersionCommand = ({ command, args, cwd, env }) => new Promise((resolveResult) => {
+	const spawn = process.platform === "win32" ? crossSpawn : nodeSpawn;
+	const child = spawn(command, args, { cwd, env, stdio: ["ignore", "pipe", "pipe"] });
+	let stdout = "";
+	let stderr = "";
+	let settled = false;
+	const settle = (result: PiVersionCommandResult) => {
+		if (settled) return;
+		settled = true;
+		resolveResult(result);
+	};
+	child.stdout?.on("data", (chunk) => { stdout += chunk.toString(); });
+	child.stderr?.on("data", (chunk) => { stderr += chunk.toString(); });
+	child.on("error", (error) => settle({ stdout, stderr, code: null, error }));
+	child.on("close", (code) => settle({ stdout, stderr, code }));
+});
+
+export async function probeWorkerPiVersion(
+	options: PiVersionProbeOptions,
+	run: RunPiVersionCommand = runPiVersionCommand,
+): Promise<PiVersionProbeResult> {
+	const command = options.command ?? "pi";
+	const versionArgs = [...versionPrefix(options.baseArgs), "--version"];
+	const key = commandCacheKey(command, versionArgs);
+	const existing = probeCache.get(key);
+	if (existing) return existing;
+
+	const pending = (async (): Promise<PiVersionProbeResult> => {
+		const common = {
+			command,
+			versionArgs,
+			hostVersion: HOST_PI_VERSION,
+			minimumVersion: MINIMUM_WORKER_PI_VERSION,
+		};
+		let result: PiVersionCommandResult;
+		try {
+			result = await run({ command, args: versionArgs, cwd: options.cwd, env: options.env });
+		} catch (error) {
+			result = { stdout: "", stderr: "", code: null, error: error instanceof Error ? error : new Error(String(error)) };
+		}
+		if (result.error || result.code !== 0) {
+			const detail = result.error?.message ?? result.stderr.trim() || `exit code ${result.code}`;
+			return {
+				...common,
+				supported: false,
+				mismatch: false,
+				message: `Cannot launch Pi worker: failed to run ${basename(command)} --version (${detail}). Install Pi ${MINIMUM_WORKER_PI_VERSION} or newer, or fix rpc.command.`,
+			};
+		}
+		const parsed = parsePiVersion(result.stdout);
+		if (!parsed) {
+			const shown = result.stdout.trim() || "no version output";
+			return {
+				...common,
+				supported: false,
+				mismatch: false,
+				message: `Cannot launch Pi worker: ${basename(command)} --version returned an unparseable version (${JSON.stringify(shown)}). Install Pi ${MINIMUM_WORKER_PI_VERSION} or newer, or fix rpc.command.`,
+			};
+		}
+		const minimum = parsePiVersion(MINIMUM_WORKER_PI_VERSION)!;
+		const supported = comparePiVersions(parsed, minimum) >= 0;
+		return {
+			...common,
+			workerVersion: parsed.text,
+			supported,
+			mismatch: supported && parsed.text !== HOST_PI_VERSION,
+			...(supported ? {} : {
+				message: `Cannot launch Pi worker: ${basename(command)} is Pi ${parsed.text}, but RPC workers require Pi ${MINIMUM_WORKER_PI_VERSION} or newer. Update the selected worker command or rpc.command.`,
+			}),
+		};
+	})();
+	probeCache.set(key, pending);
+	return pending;
+}
+
+export function clearPiVersionProbeCache(): void {
+	probeCache.clear();
+}

--- a/src/runtime/worker-manager.ts
+++ b/src/runtime/worker-manager.ts
@@ -8,6 +8,12 @@ import {
 } from "./event-normalizer.js";
 import { RpcClient, type RpcSessionState, type RpcSessionStats } from "./rpc-client.js";
 import {
+	HOST_PI_VERSION,
+	probeWorkerPiVersion,
+	type PiVersionProbeResult,
+	type ProbeWorkerPiVersion,
+} from "./pi-version.js";
+import {
 	spawnWorkerProcess,
 	type SpawnWorkerProcess,
 	type WorkerProcessHandle,
@@ -60,6 +66,14 @@ export interface ManagedWorkerRecord {
 	client: RpcClient;
 	handle: WorkerProcessHandle;
 	state: WorkerRuntimeState;
+}
+
+export interface WorkerPiVersionMismatchEvent {
+	type: "pi_version_mismatch";
+	hostVersion: string;
+	workerVersion: string;
+	command: string;
+	message: string;
 }
 
 export interface WorkerConsoleEvent {
@@ -345,17 +359,57 @@ function createWorkerProcessOptions(options: LaunchWorkerOptions): WorkerProcess
 export class WorkerManager {
 	private readonly workers = new Map<string, WorkerRuntimeRecord>();
 	private readonly emitter = new EventEmitter();
+	private readonly probeVersion: ProbeWorkerPiVersion;
 
-	constructor(private readonly spawnProcess: SpawnWorkerProcess = spawnWorkerProcess) {}
+	constructor(
+		private readonly spawnProcess: SpawnWorkerProcess = spawnWorkerProcess,
+		probeVersion?: ProbeWorkerPiVersion,
+	) {
+		// Tests and embedders that inject a fake process launcher must not
+		// accidentally execute the developer's machine-global `pi` binary.
+		this.probeVersion = probeVersion ?? (spawnProcess === spawnWorkerProcess
+			? probeWorkerPiVersion
+			: async (options) => ({
+				command: options.command ?? "pi",
+				versionArgs: ["--version"],
+				hostVersion: HOST_PI_VERSION,
+				minimumVersion: HOST_PI_VERSION,
+				workerVersion: HOST_PI_VERSION,
+				supported: true,
+				mismatch: false,
+			}));
+	}
 
 	onEvent(listener: (worker: ManagedWorkerRecord, event: NormalizedWorkerEvent) => void): () => void {
 		this.emitter.on("event", listener);
 		return () => this.emitter.off("event", listener);
 	}
 
+	onPiVersionMismatch(listener: (event: WorkerPiVersionMismatchEvent) => void): () => void {
+		this.emitter.on("pi_version_mismatch", listener);
+		return () => this.emitter.off("pi_version_mismatch", listener);
+	}
+
 	async launchWorker(options: LaunchWorkerOptions): Promise<ManagedWorkerRecord> {
 		if (this.workers.has(options.workerId)) {
 			throw new Error(`Worker already exists: ${options.workerId}`);
+		}
+
+		const version = await this.probeVersion({
+			command: options.command,
+			baseArgs: options.baseArgs,
+			cwd: options.cwd,
+			env: options.env,
+		});
+		this.assertSupportedWorkerVersion(version);
+		if (version.mismatch && version.workerVersion) {
+			this.emitter.emit("pi_version_mismatch", {
+				type: "pi_version_mismatch",
+				hostVersion: version.hostVersion,
+				workerVersion: version.workerVersion,
+				command: version.command,
+				message: `Pi Agents Team: host Pi ${version.hostVersion} is launching worker Pi ${version.workerVersion} via ${version.command}; the supported version mismatch is non-fatal.`,
+			} satisfies WorkerPiVersionMismatchEvent);
 		}
 
 		const handle = this.spawnProcess(createWorkerProcessOptions(options));
@@ -1046,6 +1100,12 @@ export class WorkerManager {
 			contextPercent,
 			contextRemainingTokens,
 		};
+	}
+
+	private assertSupportedWorkerVersion(version: PiVersionProbeResult): void {
+		if (!version.supported) {
+			throw new Error(version.message ?? `Cannot launch Pi worker: unsupported Pi version from ${version.command}.`);
+		}
 	}
 
 	private requireWorker(workerId: string): WorkerRuntimeRecord {

--- a/src/runtime/worker-manager.ts
+++ b/src/runtime/worker-manager.ts
@@ -401,7 +401,7 @@ export class WorkerManager {
 			cwd: options.cwd,
 			env: options.env,
 		});
-		this.assertSupportedWorkerVersion(version);
+		this.assertSupportedWorkerVersion(version, options.workerId);
 		if (version.mismatch && version.workerVersion) {
 			this.emitter.emit("pi_version_mismatch", {
 				type: "pi_version_mismatch",
@@ -1102,9 +1102,10 @@ export class WorkerManager {
 		};
 	}
 
-	private assertSupportedWorkerVersion(version: PiVersionProbeResult): void {
+	private assertSupportedWorkerVersion(version: PiVersionProbeResult, workerId: string): void {
 		if (!version.supported) {
-			throw new Error(version.message ?? `Cannot launch Pi worker: unsupported Pi version from ${version.command}.`);
+			const detail = version.message ?? `Cannot launch Pi worker: unsupported Pi version from ${version.command}.`;
+			throw new Error(`Worker launch failed for ${workerId}: ${detail}`);
 		}
 	}
 

--- a/src/runtime/worker-manager.ts
+++ b/src/runtime/worker-manager.ts
@@ -5,18 +5,18 @@ import {
 	createWorkerStateEvent,
 	normalizeRpcEvent,
 	type NormalizedWorkerEvent,
-} from "./event-normalizer";
-import { RpcClient, type RpcSessionState, type RpcSessionStats } from "./rpc-client";
+} from "./event-normalizer.js";
+import { RpcClient, type RpcSessionState, type RpcSessionStats } from "./rpc-client.js";
 import {
 	spawnWorkerProcess,
 	type SpawnWorkerProcess,
 	type WorkerProcessHandle,
 	type WorkerProcessOptions,
-} from "./worker-process";
-import { buildWorkerSummaryFromText, extractRelayQuestions } from "../comms/summary";
-import { extractFinalAnswer, parseFinalAnswerSummaryFields } from "./final-answer";
-export { extractFinalAnswer } from "./final-answer";
-import { THINKING_LEVELS } from "../types";
+} from "./worker-process.js";
+import { buildWorkerSummaryFromText, extractRelayQuestions } from "../comms/summary.js";
+import { extractFinalAnswer, parseFinalAnswerSummaryFields } from "./final-answer.js";
+export { extractFinalAnswer } from "./final-answer.js";
+import { THINKING_LEVELS } from "../types.js";
 import type {
 	DelegatedTaskInput,
 	ThinkingLevel,
@@ -26,7 +26,7 @@ import type {
 	WorkerStatus,
 	WorkerSummary,
 	WorkerUsageStats,
-} from "../types";
+} from "../types.js";
 
 const REUSABLE_STATUSES: ReadonlySet<WorkerStatus> = new Set<WorkerStatus>(["idle", "waiting_followup"]);
 const UNREACHABLE_TERMINAL_STATUSES: ReadonlySet<WorkerStatus> = new Set<WorkerStatus>([

--- a/src/runtime/worker-process.ts
+++ b/src/runtime/worker-process.ts
@@ -2,7 +2,7 @@ import { spawn as nodeSpawn, type ChildProcessWithoutNullStreams } from "node:ch
 import { EventEmitter } from "node:events";
 import { createRequire } from "node:module";
 import type { Readable, Writable } from "node:stream";
-import type { ThinkingLevel, WorkerExtensionMode, WorkerProjectTrustOverride } from "../types";
+import type { ThinkingLevel, WorkerExtensionMode, WorkerProjectTrustOverride } from "../types.js";
 
 const require = createRequire(import.meta.url);
 const crossSpawn = require("cross-spawn") as typeof nodeSpawn;

--- a/src/safety/launch-policy.ts
+++ b/src/safety/launch-policy.ts
@@ -1,18 +1,18 @@
-import { mkdtempSync, realpathSync, writeFileSync } from "node:fs";
+import { mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { dirname, isAbsolute, join, relative, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
-import { DEFAULT_TEAM_CONFIG } from "../config";
-import { getWorkerPromptPath, loadWorkerPrompt } from "../prompts/contracts";
-import { GENERIC_WORKER_PROMPT_SENTINEL } from "../project-config/loader";
+import { join, resolve } from "node:path";
+import { DEFAULT_TEAM_CONFIG } from "../config.js";
+import { getWorkerPromptPath, loadWorkerPrompt } from "../prompts/contracts.js";
+import { GENERIC_WORKER_PROMPT_SENTINEL } from "../project-config/loader.js";
 import {
 	ensureWriteScope,
 	isPathScopeNarrowerOrEqual,
 	isPathScopeWithinProjectRoot,
 	isPathWithinProjectRoot,
 	normalizePathScope,
-} from "./path-scope";
-import type { TeamConfig, TeamPathScope, TeamProfileSpec, ThinkingLevel, WorkerExtensionMode } from "../types";
+} from "./path-scope.js";
+import type { TeamConfig, TeamPathScope, TeamProfileSpec, ThinkingLevel, WorkerExtensionMode } from "../types.js";
+import { isRecursiveOrchestratorExtensionSource } from "./self-extension.js";
 
 export interface LaunchPolicyRequest {
 	cwd: string;
@@ -71,78 +71,6 @@ function isExtensionModeNarrowerOrEqual(candidate: WorkerExtensionMode, baseline
  * "bash as escape hatch" for the full rationale.
  */
 const WRITE_CAPABLE_TOOLS: ReadonlySet<string> = new Set(["edit", "write"]);
-const SELF_EXTENSION_PACKAGE_NAME = "pi-agents-team";
-const SELF_EXTENSION_ENTRYPOINTS = [
-	"extensions/index.ts",
-	"extensions/pi-agent-team/index.ts",
-] as const;
-const SELF_EXTENSION_PACKAGE_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
-const SELF_EXTENSION_PATHS: ReadonlySet<string> = new Set(
-	SELF_EXTENSION_ENTRYPOINTS.flatMap((entrypoint) => {
-		const path = resolve(SELF_EXTENSION_PACKAGE_ROOT, entrypoint);
-		const realPath = realpathOrSelf(path);
-		return realPath === path ? [path] : [path, realPath];
-	}),
-);
-
-function realpathOrSelf(path: string): string {
-	try {
-		return realpathSync.native(path);
-	} catch {
-		return path;
-	}
-}
-
-function isSelfPackageExtensionSource(source: string): boolean {
-	const spec = source.startsWith("npm:") ? source.slice("npm:".length) : source;
-	const escapedName = SELF_EXTENSION_PACKAGE_NAME.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-	if (new RegExp(`^${escapedName}(?:@[^/]+)?(?:/|$)`).test(spec)) return true;
-	return getExtensionSourceTail(source) === SELF_EXTENSION_PACKAGE_NAME;
-}
-
-function getExtensionSourceTail(source: string): string | undefined {
-	let spec = source.trim();
-	if (spec.startsWith("npm:")) spec = spec.slice("npm:".length);
-	if (spec.startsWith("git+")) spec = spec.slice("git+".length);
-	if (spec.startsWith("git:")) spec = spec.slice("git:".length);
-	try {
-		const url = new URL(spec);
-		spec = url.pathname;
-	} catch {
-		const scpLikeMatch = /^[^@/\s]+@[^:\s]+:(.+)$/.exec(spec);
-		if (scpLikeMatch?.[1]) spec = scpLikeMatch[1];
-	}
-	spec = spec.split(/[?#]/, 1)[0] ?? spec;
-	const tail = spec.split(/[\\/]/).filter((part) => part.length > 0).at(-1);
-	return tail?.replace(/\.git$/i, "").replace(/@[^@/]+$/, "");
-}
-
-function isPathLikeExtensionSource(source: string): boolean {
-	if (isAbsolute(source) || /^[a-zA-Z]:[\\/]/.test(source)) return true;
-	if (source === "." || source === ".." || source.startsWith("./") || source.startsWith("../")) return true;
-	if (source === "extensions") return true;
-	if (source.startsWith("npm:") || source.startsWith("git:") || source.startsWith("http://") || source.startsWith("https://")) return false;
-	if (source.startsWith("@")) return false;
-	return /[\\/]/.test(source);
-}
-
-function isSameOrAncestorPath(candidate: string, target: string): boolean {
-	const rel = relative(candidate, target);
-	return rel === "" || (rel.length > 0 && !rel.startsWith("..") && !isAbsolute(rel));
-}
-
-export function isRecursiveOrchestratorExtensionSource(source: string, baseDir: string): boolean {
-	const trimmed = source.trim();
-	if (trimmed.length === 0) return false;
-	if (isSelfPackageExtensionSource(trimmed)) return true;
-	if (!isPathLikeExtensionSource(trimmed)) return false;
-
-	const resolved = isAbsolute(trimmed) ? trimmed : resolve(baseDir, trimmed);
-	const realResolved = realpathOrSelf(resolved);
-	return [...SELF_EXTENSION_PATHS].some(
-		(selfPath) => isSameOrAncestorPath(resolved, selfPath) || isSameOrAncestorPath(realResolved, selfPath),
-	);
-}
 
 function rejectRecursiveOrchestratorExtensions(sources: readonly string[] | undefined, baseDir: string): void {
 	const blockedSource = sources?.find((source) => isRecursiveOrchestratorExtensionSource(source, baseDir));

--- a/src/safety/path-scope.ts
+++ b/src/safety/path-scope.ts
@@ -1,6 +1,6 @@
 import { realpathSync } from "node:fs";
 import { resolve, sep } from "node:path";
-import type { TeamPathScope } from "../types";
+import type { TeamPathScope } from "../types.js";
 
 /**
  * Resolve `path` through symlinks if it exists; otherwise return the lexical

--- a/src/safety/self-extension.ts
+++ b/src/safety/self-extension.ts
@@ -1,0 +1,99 @@
+import { realpathSync } from "node:fs";
+import { dirname, extname, isAbsolute, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const SELF_EXTENSION_PACKAGE_NAME = "pi-agents-team";
+const SOURCE_ENTRYPOINTS = [
+	"extensions/index.ts",
+	"extensions/pi-agent-team/index.ts",
+] as const;
+const COMPILED_ENTRYPOINTS = [
+	"dist/extensions/index.js",
+	"dist/extensions/pi-agent-team/index.js",
+] as const;
+
+function realpathOrSelf(path: string): string {
+	try {
+		return realpathSync.native(path);
+	} catch {
+		return path;
+	}
+}
+
+/**
+ * Derive self-entry candidates from this module's source or compiled location.
+ * Source modules live at <package>/src/safety; published modules live at
+ * <package>/dist/src/safety. The module extension distinguishes those verified
+ * forms without treating a source package directory named `dist` as emitted
+ * output. Keeping both layouts in the candidate set lets a source checkout
+ * reject its generated dist entry without requiring dist to exist, while an
+ * installed package rejects its compiled entry.
+ */
+export function getOrchestratorSelfEntryPaths(modulePath = fileURLToPath(import.meta.url)): ReadonlySet<string> {
+	const moduleFilePath = modulePath.startsWith("file:") ? fileURLToPath(modulePath) : modulePath;
+	const layoutRoot = resolve(dirname(moduleFilePath), "../..");
+	const packageRoot = extname(moduleFilePath) === ".js" ? dirname(layoutRoot) : layoutRoot;
+	const entrypoints = [...SOURCE_ENTRYPOINTS, ...COMPILED_ENTRYPOINTS];
+	return new Set(
+		entrypoints.flatMap((entrypoint) => {
+			const path = resolve(packageRoot, entrypoint);
+			const realPath = realpathOrSelf(path);
+			return realPath === path ? [path] : [path, realPath];
+		}),
+	);
+}
+
+function isSelfPackageExtensionSource(source: string): boolean {
+	const spec = source.startsWith("npm:") ? source.slice("npm:".length) : source;
+	const escapedName = SELF_EXTENSION_PACKAGE_NAME.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+	if (new RegExp(`^${escapedName}(?:@[^/]+)?(?:/|$)`).test(spec)) return true;
+	return getExtensionSourceTail(source) === SELF_EXTENSION_PACKAGE_NAME;
+}
+
+function getExtensionSourceTail(source: string): string | undefined {
+	let spec = source.trim();
+	if (spec.startsWith("npm:")) spec = spec.slice("npm:".length);
+	if (spec.startsWith("git+")) spec = spec.slice("git+".length);
+	if (spec.startsWith("git:")) spec = spec.slice("git:".length);
+	try {
+		const url = new URL(spec);
+		spec = url.pathname;
+	} catch {
+		const scpLikeMatch = /^[^@/\s]+@[^:\s]+:(.+)$/.exec(spec);
+		if (scpLikeMatch?.[1]) spec = scpLikeMatch[1];
+	}
+	spec = spec.split(/[?#]/, 1)[0] ?? spec;
+	const tail = spec.split(/[\\/]/).filter((part) => part.length > 0).at(-1);
+	return tail?.replace(/\.git$/i, "").replace(/@[^@/]+$/, "");
+}
+
+function isPathLikeExtensionSource(source: string): boolean {
+	if (isAbsolute(source) || /^[a-zA-Z]:[\\/]/.test(source)) return true;
+	if (source === "." || source === ".." || source.startsWith("./") || source.startsWith("../")) return true;
+	if (source === "extensions") return true;
+	if (source.startsWith("npm:") || source.startsWith("git:") || source.startsWith("http://") || source.startsWith("https://")) return false;
+	if (source.startsWith("@")) return false;
+	return /[\\/]/.test(source);
+}
+
+function isSameOrAncestorPath(candidate: string, target: string): boolean {
+	const rel = relative(candidate, target);
+	return rel === "" || (rel.length > 0 && !rel.startsWith("..") && !isAbsolute(rel));
+}
+
+export function isRecursiveOrchestratorExtensionSource(
+	source: string,
+	baseDir: string,
+	modulePath = fileURLToPath(import.meta.url),
+): boolean {
+	const trimmed = source.trim();
+	if (trimmed.length === 0) return false;
+	if (isSelfPackageExtensionSource(trimmed)) return true;
+	if (!isPathLikeExtensionSource(trimmed)) return false;
+
+	const resolved = isAbsolute(trimmed) ? resolve(trimmed) : resolve(baseDir, trimmed);
+	const realResolved = realpathOrSelf(resolved);
+	return [...getOrchestratorSelfEntryPaths(modulePath)].some(
+		(selfPath) => isSameOrAncestorPath(resolved, selfPath) || isSameOrAncestorPath(realResolved, selfPath),
+	);
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -28,7 +28,7 @@ export function isPackagedProfileName(name: string): name is TeamProfileName {
 	return (TEAM_PROFILE_NAMES as readonly string[]).includes(name);
 }
 
-export const THINKING_LEVELS = ["off", "minimal", "low", "medium", "high", "xhigh"] as const;
+export const THINKING_LEVELS = ["off", "minimal", "low", "medium", "high", "xhigh", "max"] as const;
 export type ThinkingLevel = (typeof THINKING_LEVELS)[number];
 
 export const WORKER_EXTENSION_MODES = ["inherit", "disable", "worker-minimal"] as const;

--- a/src/types.ts
+++ b/src/types.ts
@@ -48,7 +48,7 @@ import {
 	TEAM_PROJECT_SCHEMA_VERSION,
 	TEAM_PROJECT_SCHEMA_VERSIONS_SUPPORTED,
 	TEAM_SCAFFOLD_VERSION,
-} from "./project-config/versions";
+} from "./project-config/versions.js";
 export { TEAM_PROJECT_SCHEMA_VERSION, TEAM_PROJECT_SCHEMA_VERSIONS_SUPPORTED, TEAM_SCAFFOLD_VERSION };
 export const DEFAULT_MODEL_SENTINEL = "default" as const;
 export const DEFAULT_PROMPT_SENTINEL = "default" as const;

--- a/src/ui/autocomplete.ts
+++ b/src/ui/autocomplete.ts
@@ -3,7 +3,7 @@ import type {
 	AutocompleteProvider,
 	AutocompleteSuggestions,
 } from "@earendil-works/pi-tui";
-import type { TeamConfig, WorkerRuntimeState } from "../types";
+import type { TeamConfig, WorkerRuntimeState } from "../types.js";
 
 const MAX_TEAM_AUTOCOMPLETE_ITEMS = 20;
 

--- a/src/ui/copy-payload.ts
+++ b/src/ui/copy-payload.ts
@@ -1,9 +1,9 @@
-import type { WorkerActivityEvent, WorkerConsoleEvent } from "../runtime/worker-manager";
-import type { WorkerRuntimeState } from "../types";
-import { parseFinalAnswerSummaryFields } from "../runtime/final-answer";
-import { sanitizeTerminalText } from "./theme";
-import { formatRetainedTranscript } from "./transcript-retention";
-import { hasCacheUsage } from "./usage-format";
+import type { WorkerActivityEvent, WorkerConsoleEvent } from "../runtime/worker-manager.js";
+import type { WorkerRuntimeState } from "../types.js";
+import { parseFinalAnswerSummaryFields } from "../runtime/final-answer.js";
+import { sanitizeTerminalText } from "./theme.js";
+import { formatRetainedTranscript } from "./transcript-retention.js";
+import { hasCacheUsage } from "./usage-format.js";
 
 function formatTs(ts: number): string {
 	const date = new Date(ts);

--- a/src/ui/dashboard.ts
+++ b/src/ui/dashboard.ts
@@ -1,6 +1,6 @@
 import { truncateToWidth } from "@earendil-works/pi-tui";
 import type { Theme } from "@earendil-works/pi-coding-agent";
-import { compareWorkerIds, type PersistedTeamState, type WorkerRuntimeState } from "../types";
+import { compareWorkerIds, type PersistedTeamState, type WorkerRuntimeState } from "../types.js";
 import {
 	WORKER_ATTENTION_ORDER,
 	formatWorkerLabel,
@@ -9,9 +9,9 @@ import {
 	getWorkerAttentionPriority as getSharedWorkerAttentionPriority,
 	getWorkerPrimaryAction,
 	type WorkerAttentionPriority,
-} from "./display-grammar";
-import { themedPalette } from "./theme";
-import { formatCompactTokenCount } from "./usage-format";
+} from "./display-grammar.js";
+import { themedPalette } from "./theme.js";
+import { formatCompactTokenCount } from "./usage-format.js";
 
 export type WorkerAttentionGroup = WorkerAttentionPriority;
 

--- a/src/ui/display-grammar.ts
+++ b/src/ui/display-grammar.ts
@@ -1,4 +1,4 @@
-import { compareWorkerIds, type WorkerRuntimeState, type WorkerStatus } from "../types";
+import { compareWorkerIds, type WorkerRuntimeState, type WorkerStatus } from "../types.js";
 
 export type WorkerAttentionPriority = "needs_reply" | "needs_recovery" | "in_progress" | "completed_or_idle";
 

--- a/src/ui/overlay.ts
+++ b/src/ui/overlay.ts
@@ -8,19 +8,19 @@ import {
 } from "@earendil-works/pi-tui";
 import type { Component, Focusable, OverlayOptions, SelectItem, SelectListTheme, TUI } from "@earendil-works/pi-tui";
 import { BorderedLoader } from "@earendil-works/pi-coding-agent";
-import type { AgentMessageResult, TeamManager } from "../control-plane/team-manager";
-import type { AssistantChunk, WorkerActivityEvent, WorkerConsoleEvent } from "../runtime/worker-manager";
-import { extractFinalAnswer, parseFinalAnswerSummaryFields } from "../runtime/final-answer";
-import { type PersistedTeamState, type WorkerRuntimeState, type WorkerStatus } from "../types";
-import { aggregateWorkerUsage, hasWorkerUsage } from "../usage";
-import { copyToClipboard } from "../util/clipboard";
-import { buildCopyPayload } from "./copy-payload";
-import { buildActionSummaryLine, buildCompactTeamSummaryLine, buildRosterSections, buildTeamDashboardText, buildWorkerPrioritySnippet, type WorkerAttentionGroup } from "./dashboard";
-import { formatRetainedTranscript } from "./transcript-retention";
-import { formatCacheUsage, formatCompactTokenCount, formatContextBudget } from "./usage-format";
-import { formatWorkerLabel, formatWorkerStatusLabel, getWorkerAttentionDisplay, getWorkerAttentionPriority, getWorkerPrimaryAction } from "./display-grammar";
-import { formatAgentMessageResult } from "./tool-formatters";
-import { FRAME, stripAnsi, sanitizeTerminalText, fallbackPalette, themedPalette, type ThemedPalette } from "./theme";
+import type { AgentMessageResult, TeamManager } from "../control-plane/team-manager.js";
+import type { AssistantChunk, WorkerActivityEvent, WorkerConsoleEvent } from "../runtime/worker-manager.js";
+import { extractFinalAnswer, parseFinalAnswerSummaryFields } from "../runtime/final-answer.js";
+import { type PersistedTeamState, type WorkerRuntimeState, type WorkerStatus } from "../types.js";
+import { aggregateWorkerUsage, hasWorkerUsage } from "../usage.js";
+import { copyToClipboard } from "../util/clipboard.js";
+import { buildCopyPayload } from "./copy-payload.js";
+import { buildActionSummaryLine, buildCompactTeamSummaryLine, buildRosterSections, buildTeamDashboardText, buildWorkerPrioritySnippet, type WorkerAttentionGroup } from "./dashboard.js";
+import { formatRetainedTranscript } from "./transcript-retention.js";
+import { formatCacheUsage, formatCompactTokenCount, formatContextBudget } from "./usage-format.js";
+import { formatWorkerLabel, formatWorkerStatusLabel, getWorkerAttentionDisplay, getWorkerAttentionPriority, getWorkerPrimaryAction } from "./display-grammar.js";
+import { formatAgentMessageResult } from "./tool-formatters.js";
+import { FRAME, stripAnsi, sanitizeTerminalText, fallbackPalette, themedPalette, type ThemedPalette } from "./theme.js";
 
 // The overlay is a single-instance custom component. Styling helpers delegate
 // to a mutable palette so the Pi Theme object supplied by ctx.ui.custom can be

--- a/src/ui/status-widget.ts
+++ b/src/ui/status-widget.ts
@@ -1,10 +1,10 @@
 import { truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
 import type { Theme } from "@earendil-works/pi-coding-agent";
-import { compareWorkerIds, type PersistedTeamState, type WorkerRuntimeState, type WorkerStatus } from "../types";
-import { aggregateWorkerUsage, hasWorkerUsage } from "../usage";
-import { formatProfileLabel, formatWorkerDisplayId, formatWorkerStatusLabel, getWorkerAttentionDisplay, getWorkerAttentionPriority, getWorkerStatusGlyph } from "./display-grammar";
-import { bold as legacyBold, themedPalette, type ThemedPalette } from "./theme";
-import { formatCacheUsage, formatCacheUsageWithHit, formatCompactTokenCount } from "./usage-format";
+import { compareWorkerIds, type PersistedTeamState, type WorkerRuntimeState, type WorkerStatus } from "../types.js";
+import { aggregateWorkerUsage, hasWorkerUsage } from "../usage.js";
+import { formatProfileLabel, formatWorkerDisplayId, formatWorkerStatusLabel, getWorkerAttentionDisplay, getWorkerAttentionPriority, getWorkerStatusGlyph } from "./display-grammar.js";
+import { bold as legacyBold, themedPalette, type ThemedPalette } from "./theme.js";
+import { formatCacheUsage, formatCacheUsageWithHit, formatCompactTokenCount } from "./usage-format.js";
 
 export const SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
 export const TEAM_STATUS_TIPS = [

--- a/src/ui/tool-formatters.ts
+++ b/src/ui/tool-formatters.ts
@@ -1,7 +1,7 @@
 import { truncateToWidth, visibleWidth as measureVisibleWidth } from "@earendil-works/pi-tui";
-import type { DelegatedTaskInput, WorkerRuntimeState, WorkerStatus } from "../types";
-import { formatProfileLabel, formatWorkerDisplayId, formatWorkerIdList, formatWorkerLabel, formatWorkerStatusLabel, formatWorkerToolLabel } from "./display-grammar";
-import { formatContextBudget } from "./usage-format";
+import type { DelegatedTaskInput, WorkerRuntimeState, WorkerStatus } from "../types.js";
+import { formatProfileLabel, formatWorkerDisplayId, formatWorkerIdList, formatWorkerLabel, formatWorkerStatusLabel, formatWorkerToolLabel } from "./display-grammar.js";
+import { formatContextBudget } from "./usage-format.js";
 
 export const TOOL_SECTION_LABELS = {
 	worker: "Worker",

--- a/src/ui/tool-renderers.ts
+++ b/src/ui/tool-renderers.ts
@@ -1,5 +1,5 @@
 import { Text } from "@earendil-works/pi-tui";
-import { type AgentToolName, type AgentToolTitleArgs, buildAgentToolCallTitle } from "./display-grammar";
+import { type AgentToolName, type AgentToolTitleArgs, buildAgentToolCallTitle } from "./display-grammar.js";
 
 type MutableText = Text & { setText(text: string): void };
 

--- a/src/ui/transcript-retention.ts
+++ b/src/ui/transcript-retention.ts
@@ -1,4 +1,4 @@
-import { sanitizeTerminalText } from "./theme";
+import { sanitizeTerminalText } from "./theme.js";
 
 export const DISPLAY_TRANSCRIPT_BYTE_CAP = 256 * 1024;
 export const DISPLAY_TRANSCRIPT_LINE_CAP = 4000;

--- a/src/ui/usage-format.ts
+++ b/src/ui/usage-format.ts
@@ -1,4 +1,4 @@
-import type { WorkerUsageAggregate, WorkerUsageStats } from "../types";
+import type { WorkerUsageAggregate, WorkerUsageStats } from "../types.js";
 
 /**
  * Format token counts for narrow status surfaces.

--- a/src/usage.ts
+++ b/src/usage.ts
@@ -1,4 +1,4 @@
-import type { WorkerRuntimeState, WorkerUsageAggregate, WorkerUsageStats } from "./types";
+import type { WorkerRuntimeState, WorkerUsageAggregate, WorkerUsageStats } from "./types.js";
 
 function numericField(value: unknown): number {
 	return typeof value === "number" && Number.isFinite(value) ? value : 0;

--- a/tests/commands/team-init.test.ts
+++ b/tests/commands/team-init.test.ts
@@ -10,6 +10,9 @@ import {
 	DEFAULT_PROMPT_SENTINEL,
 	TEAM_PROJECT_CONFIG_DIR,
 	TEAM_PROJECT_CONFIG_FILE,
+	TEAM_PROJECT_SCHEMA_VERSION,
+	TEAM_SCAFFOLD_VERSION,
+	THINKING_LEVELS,
 } from "../../src/types";
 
 interface RegisteredCommand {
@@ -48,8 +51,23 @@ test("parseInitArgs accepts scope and force flag", () => {
 
 test("buildFullScaffold pre-populates every builtin profile in the schema v4 shape", () => {
 	const scaffold = _testing.buildFullScaffold();
-	assert.equal(scaffold.schemaVersion, 4);
+	assert.equal(TEAM_PROJECT_SCHEMA_VERSION, 4, "additive thinking levels must not bump the config schema");
+	assert.equal(TEAM_SCAFFOLD_VERSION, 3, "opt-in thinking levels must not change generated defaults");
+	assert.equal(scaffold.schemaVersion, TEAM_PROJECT_SCHEMA_VERSION);
 	assert.equal(scaffold.scaffoldVersion, CURRENT_SCAFFOLD_VERSION);
+	assert.deepEqual(
+		Object.fromEntries(DEFAULT_TEAM_CONFIG.profiles.map((profile) => [profile.name, profile.thinkingLevel])),
+		{
+			explorer: "low",
+			librarian: "medium",
+			oracle: "high",
+			designer: "medium",
+			fixer: "medium",
+			reviewer: "high",
+			observer: "low",
+		},
+		"built-in role thinking defaults must remain unchanged",
+	);
 	assert.equal(scaffold.enabled, true);
 	assert.equal(scaffold.routingMode, "team");
 	assert.equal(scaffold.workerAccess?.allowPathsOutsideProject, true);
@@ -105,6 +123,8 @@ test("/team-init local writes a full scaffold inside the project", async () => {
 	const roleNames = Object.keys(parsed.roles ?? {}).sort();
 	assert.deepEqual(roleNames, DEFAULT_TEAM_CONFIG.profiles.map((profile) => profile.name).sort());
 	assert.ok(emitted[0]?.includes(expectedPath));
+	assert.ok(emitted[0]?.includes(`valid values: ${THINKING_LEVELS.join(", ")}`));
+	assert.ok(emitted[0]?.includes("max"));
 	assert.ok(emitted[0]?.includes("/reload"));
 });
 

--- a/tests/control-plane/extension-wiring.test.ts
+++ b/tests/control-plane/extension-wiring.test.ts
@@ -3,7 +3,7 @@ import assert from "node:assert/strict";
 import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import extension from "../../extensions/pi-agent-team/index";
+import extension, { _testing } from "../../extensions/pi-agent-team/index";
 import { createDefaultTeamState, DEFAULT_TEAM_CONFIG } from "../../src/config";
 
 interface RegisteredTool {
@@ -47,6 +47,24 @@ function makeWidgetState() {
 	};
 	return state;
 }
+
+test("extension mismatch notifier emits exactly one non-fatal session warning", () => {
+	const warnings: string[] = [];
+	const notifier = _testing.createPiVersionMismatchNotifier((message) => warnings.push(message));
+	const event = {
+		type: "pi_version_mismatch" as const,
+		hostVersion: "0.80.6",
+		workerVersion: "0.81.0",
+		command: "custom-pi",
+		message: "Pi Agents Team: host Pi 0.80.6 is launching worker Pi 0.81.0 via custom-pi; the supported version mismatch is non-fatal.",
+	};
+	notifier.notify(event);
+	notifier.notify({ ...event, workerVersion: "0.82.0" });
+	assert.deepEqual(warnings, [event.message]);
+	notifier.reset();
+	notifier.notify(event);
+	assert.equal(warnings.length, 2, "a new session may warn once again");
+});
 
 test("extension registers control-plane tools and operator commands", () => {
 	const tools: RegisteredTool[] = [];

--- a/tests/package-manifest.test.ts
+++ b/tests/package-manifest.test.ts
@@ -1,12 +1,14 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 
 const packageJson = JSON.parse(readFileSync("package.json", "utf8")) as {
 	main?: string;
 	exports?: { "."?: { types?: string; default?: string } };
 	files?: string[];
 	pi?: { extensions?: string[]; prompts?: string[] };
+	peerDependencies?: Record<string, string>;
+	devDependencies?: Record<string, string>;
 };
 
 test("package manifest exposes only the compiled extension and dist-contained assets", () => {
@@ -22,4 +24,23 @@ test("package manifest exposes only the compiled extension and dist-contained as
 	assert.ok(!packageJson.files?.includes("extensions"), "source extension entries must not be published");
 	assert.ok(!packageJson.files?.includes("prompts"), "worker prompts ship under dist only");
 	assert.ok(!packageJson.files?.includes("profiles"), "worker profiles ship under dist only");
+});
+
+test("package manifest locks the Pi 0.80.6 development and peer baseline", () => {
+	assert.deepEqual(
+		{
+			codingAgent: packageJson.devDependencies?.["@earendil-works/pi-coding-agent"],
+			tui: packageJson.devDependencies?.["@earendil-works/pi-tui"],
+		},
+		{ codingAgent: "0.80.6", tui: "0.80.6" },
+	);
+	assert.deepEqual(
+		{
+			codingAgent: packageJson.peerDependencies?.["@earendil-works/pi-coding-agent"],
+			tui: packageJson.peerDependencies?.["@earendil-works/pi-tui"],
+		},
+		{ codingAgent: ">=0.80.6", tui: ">=0.80.6" },
+	);
+	assert.ok(existsSync("package-lock.json"), "npm lock must be present");
+	assert.ok(!existsSync("bun.lock"), "stale Bun lock must not coexist with npm lock");
 });

--- a/tests/package-manifest.test.ts
+++ b/tests/package-manifest.test.ts
@@ -3,13 +3,23 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 
 const packageJson = JSON.parse(readFileSync("package.json", "utf8")) as {
+	main?: string;
+	exports?: { "."?: { types?: string; default?: string } };
 	files?: string[];
 	pi?: { extensions?: string[]; prompts?: string[] };
 };
 
-test("package manifest packages internal prompts without exposing prompt resources", () => {
-	assert.deepEqual(packageJson.pi?.extensions, ["./extensions/index.ts"]);
-	assert.deepEqual(packageJson.pi?.prompts, [], "explicit empty prompts list prevents Pi from exposing packaged prompt resources");
-	assert.ok(!packageJson.files?.includes("prompt-templates/"), "prompt templates must not be included in npm package files");
-	assert.ok(packageJson.files?.includes("prompts/"), "internal prompts still need to ship for worker roles");
+test("package manifest exposes only the compiled extension and dist-contained assets", () => {
+	assert.equal(packageJson.main, "./dist/extensions/index.js");
+	assert.deepEqual(packageJson.exports?.["."], {
+		types: "./dist/extensions/index.d.ts",
+		default: "./dist/extensions/index.js",
+	});
+	assert.deepEqual(packageJson.pi?.extensions, ["./dist/extensions/index.js"]);
+	assert.deepEqual(packageJson.pi?.prompts, [], "internal worker prompts must not be exposed as Pi prompt resources");
+	assert.deepEqual(packageJson.files, ["dist", "README.md", "LICENSE"]);
+	assert.ok(!packageJson.files?.includes("src"), "TypeScript sources must not be published");
+	assert.ok(!packageJson.files?.includes("extensions"), "source extension entries must not be published");
+	assert.ok(!packageJson.files?.includes("prompts"), "worker prompts ship under dist only");
+	assert.ok(!packageJson.files?.includes("profiles"), "worker profiles ship under dist only");
 });

--- a/tests/project-config/loader.test.ts
+++ b/tests/project-config/loader.test.ts
@@ -432,6 +432,9 @@ test("loadActiveTeamConfig v4: recursive self-extension sources are rejected", (
 		"./extensions/pi-agent-team/index.ts",
 		resolve(process.cwd(), "extensions/index.ts"),
 		resolve(process.cwd(), "extensions/pi-agent-team/index.ts"),
+		resolve(process.cwd(), "dist/extensions/index.js"),
+		resolve(process.cwd(), "dist/extensions/pi-agent-team/index.js"),
+		resolve(process.cwd(), "dist/extensions/../extensions/index.js"),
 	];
 
 	for (const source of sources) {

--- a/tests/project-config/loader.test.ts
+++ b/tests/project-config/loader.test.ts
@@ -741,6 +741,23 @@ test("loadActiveTeamConfig strips invalid role thinkingLevel and records a warni
 	assert.equal(reviewer?.thinkingLevel, undefined, "invalid thinkingLevel is stripped from only that role");
 });
 
+test("loadActiveTeamConfig accepts max thinkingLevel without warning", () => {
+	const root = mkdtempSync(join(tmpdir(), "pi-agent-team-thinking-max-"));
+	mkdirSync(join(root, "app"), { recursive: true });
+	writeProjectConfig(root, {
+		schemaVersion: 4,
+		roles: {
+			oracle: { thinkingLevel: "max", prompt: "default" },
+		},
+	});
+
+	const result = loadActiveTeamConfig({ cwd: join(root, "app"), globalConfigPath: null });
+	assert.equal(result.status, "project");
+	assert.deepEqual(result.thinkingLevelWarnings, []);
+	const oracle = result.config.profiles.find((profile) => profile.name === "oracle");
+	assert.equal(oracle?.thinkingLevel, "max");
+});
+
 test("loadActiveTeamConfig retains valid role thinkingLevel", () => {
 	const root = mkdtempSync(join(tmpdir(), "pi-agent-team-thinking-valid-"));
 	mkdirSync(join(root, "app"), { recursive: true });

--- a/tests/runtime/pi-version.test.ts
+++ b/tests/runtime/pi-version.test.ts
@@ -1,0 +1,87 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+	HOST_PI_VERSION,
+	clearPiVersionProbeCache,
+	comparePiVersions,
+	parsePiVersion,
+	probeWorkerPiVersion,
+	type RunPiVersionCommand,
+} from "../../src/runtime/pi-version";
+
+function runner(result: { stdout?: string; stderr?: string; code?: number | null; error?: Error }): RunPiVersionCommand {
+	return async () => ({ stdout: result.stdout ?? "", stderr: result.stderr ?? "", code: result.code ?? 0, error: result.error });
+}
+
+test.beforeEach(() => clearPiVersionProbeCache());
+
+test("uses Pi's exported VERSION as the host compatibility version", () => {
+	assert.equal(HOST_PI_VERSION, "0.80.6");
+});
+
+test("parses supported Pi version output and compares semantic components", () => {
+	assert.deepEqual(parsePiVersion("pi version v0.80.6\n"), { major: 0, minor: 80, patch: 6, text: "0.80.6" });
+	assert.ok(comparePiVersions(parsePiVersion("0.81.0")!, parsePiVersion("0.80.6")!) > 0);
+	assert.equal(parsePiVersion("not a Pi version"), undefined);
+});
+
+test("accepts the minimum, exact host, and newer worker versions", async () => {
+	for (const output of ["0.80.6", "pi 0.80.6", "0.81.0", "1.0.0-beta.1"]) {
+		clearPiVersionProbeCache();
+		const result = await probeWorkerPiVersion({ command: "custom-pi", cwd: "/tmp" }, runner({ stdout: output }));
+		assert.equal(result.supported, true, output);
+	}
+});
+
+test("rejects old, malformed, and missing worker versions with actionable diagnostics", async () => {
+	const cases = [
+		{ result: { stdout: "0.80.5" }, pattern: /Pi 0\.80\.5.*require Pi 0\.80\.6 or newer.*rpc\.command/ },
+		{ result: { stdout: "nightly" }, pattern: /unparseable version.*0\.80\.6 or newer.*rpc\.command/ },
+		{ result: { code: null, error: new Error("spawn ENOENT") }, pattern: /failed to run custom-pi --version.*ENOENT.*0\.80\.6 or newer.*rpc\.command/ },
+	];
+	for (const entry of cases) {
+		clearPiVersionProbeCache();
+		const result = await probeWorkerPiVersion({ command: "custom-pi", cwd: "/tmp" }, runner(entry.result));
+		assert.equal(result.supported, false);
+		assert.match(result.message ?? "", entry.pattern);
+	}
+});
+
+test("reports supported host/worker mismatch but not an exact match", async () => {
+	const exact = await probeWorkerPiVersion({ command: "exact", cwd: "/tmp" }, runner({ stdout: HOST_PI_VERSION }));
+	const mismatch = await probeWorkerPiVersion({ command: "newer", cwd: "/tmp" }, runner({ stdout: "0.81.0" }));
+	assert.equal(exact.mismatch, false);
+	assert.equal(mismatch.mismatch, true);
+	assert.equal(mismatch.workerVersion, "0.81.0");
+});
+
+test("caches probes and coalesces concurrent first probes by command", async () => {
+	let calls = 0;
+	let release!: () => void;
+	const blocked = new Promise<void>((resolve) => { release = resolve; });
+	const run: RunPiVersionCommand = async () => {
+		calls += 1;
+		await blocked;
+		return { stdout: "0.80.6", stderr: "", code: 0 };
+	};
+	const options = { command: "coalesced-pi", cwd: "/tmp" };
+	const first = probeWorkerPiVersion(options, run);
+	const second = probeWorkerPiVersion(options, run);
+	assert.equal(calls, 1);
+	release();
+	assert.strictEqual(await first, await second);
+	await probeWorkerPiVersion(options, run);
+	assert.equal(calls, 1);
+});
+
+test("keeps custom CLI entrypoint args while replacing RPC flags with --version", async () => {
+	let observed: string[] = [];
+	await probeWorkerPiVersion(
+		{ command: process.execPath, baseArgs: ["dist/cli.js", "--mode", "rpc", "--no-session"], cwd: "/tmp" },
+		async ({ args }) => {
+			observed = args;
+			return { stdout: "0.80.6", stderr: "", code: 0 };
+		},
+	);
+	assert.deepEqual(observed, ["dist/cli.js", "--version"]);
+});

--- a/tests/runtime/worker-process.test.ts
+++ b/tests/runtime/worker-process.test.ts
@@ -1,6 +1,9 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { buildWorkerProcessArgs, resolveWorkerSpawnImplementation, spawnWorkerProcess } from "../../src/runtime/worker-process";
+import { WorkerManager } from "../../src/runtime/worker-manager";
+import { HOST_PI_VERSION, type ProbeWorkerPiVersion } from "../../src/runtime/pi-version";
+import { MockWorkerHandle, MockWorkerTransport } from "./test-helpers";
 
 test("buildWorkerProcessArgs maps trusted project decision to --approve", () => {
 	const args = buildWorkerProcessArgs({ cwd: process.cwd(), projectTrust: "approve" });
@@ -113,6 +116,68 @@ test("resolveWorkerSpawnImplementation uses cross-spawn on Windows", () => {
 	assert.equal(resolveWorkerSpawnImplementation("win32"), "cross-spawn");
 	assert.equal(resolveWorkerSpawnImplementation("darwin"), "node:child_process");
 	assert.equal(resolveWorkerSpawnImplementation("linux"), "node:child_process");
+});
+
+test("WorkerManager rejects an unsupported worker before RPC process launch", async () => {
+	let launches = 0;
+	const manager = new WorkerManager(
+		() => {
+			launches += 1;
+			return new MockWorkerHandle(new MockWorkerTransport());
+		},
+		async () => ({
+			command: "old-pi",
+			versionArgs: ["--version"],
+			hostVersion: HOST_PI_VERSION,
+			minimumVersion: "0.80.6",
+			workerVersion: "0.80.5",
+			supported: false,
+			mismatch: false,
+			message: "Cannot launch Pi worker: old-pi is Pi 0.80.5, but RPC workers require Pi 0.80.6 or newer. Update the selected worker command or rpc.command.",
+		}),
+	);
+	await assert.rejects(
+		manager.launchWorker({ workerId: "old", profileName: "fixer", task: {} as any, cwd: process.cwd() }),
+		/RPC workers require Pi 0\.80\.6 or newer/,
+	);
+	assert.equal(launches, 0);
+});
+
+test("WorkerManager injects the selected command into preflight and emits mismatch diagnostics", async () => {
+	const probes: Array<{ command?: string; baseArgs?: string[] }> = [];
+	const probe: ProbeWorkerPiVersion = async (options) => {
+		probes.push(options);
+		return {
+			command: options.command ?? "pi",
+			versionArgs: ["--version"],
+			hostVersion: HOST_PI_VERSION,
+			minimumVersion: "0.80.6",
+			workerVersion: "0.81.0",
+			supported: true,
+			mismatch: true,
+		};
+	};
+	const manager = new WorkerManager(() => new MockWorkerHandle(new MockWorkerTransport()), probe);
+	const warnings: string[] = [];
+	manager.onPiVersionMismatch((event) => warnings.push(event.message));
+	await manager.launchWorker({
+		workerId: "newer",
+		profileName: "fixer",
+		task: {} as any,
+		cwd: process.cwd(),
+		command: "custom-pi",
+		baseArgs: ["--mode", "rpc", "--no-session"],
+	});
+	assert.deepEqual(probes, [{ command: "custom-pi", baseArgs: ["--mode", "rpc", "--no-session"], cwd: process.cwd(), env: undefined }]);
+	assert.deepEqual(warnings, ["Pi Agents Team: host Pi 0.80.6 is launching worker Pi 0.81.0 via custom-pi; the supported version mismatch is non-fatal."]);
+	await manager.dispose();
+});
+
+test("injected worker launchers do not probe the machine-global Pi by default", async () => {
+	const manager = new WorkerManager(() => new MockWorkerHandle(new MockWorkerTransport()));
+	await manager.launchWorker({ workerId: "injected", profileName: "fixer", task: {} as any, cwd: process.cwd(), command: "custom-test-pi" });
+	assert.equal(manager.hasWorker("injected"), true);
+	await manager.dispose();
 });
 
 test("spawnWorkerProcess converts child_process spawn errors into waitForExit failure info", async () => {

--- a/tests/safety/launch-policy.test.ts
+++ b/tests/safety/launch-policy.test.ts
@@ -1,5 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import { resolve } from "node:path";
 import { resolveProfile } from "../../src/profiles/loader";
 import { applyLaunchPolicy } from "../../src/safety/launch-policy";
 import type { TeamProfileSpec } from "../../src/types";
@@ -70,4 +71,26 @@ test("applyLaunchPolicy keeps model cascade independent from thinkingLevel casca
 
 	assert.equal(plan.model, "orchestrator/fallback-model");
 	assert.equal(plan.thinkingLevel, "minimal");
+});
+
+test("applyLaunchPolicy rejects source and compiled orchestrator entries", () => {
+	for (const extension of [
+		resolve(process.cwd(), "extensions/index.ts"),
+		resolve(process.cwd(), "dist/extensions/index.js"),
+		resolve(process.cwd(), "dist/extensions/pi-agent-team/index.js"),
+	]) {
+		const profile = { ...resolveProfile("reviewer"), extensions: [extension] };
+		assert.throws(
+			() => applyLaunchPolicy({ cwd: process.cwd(), profile }),
+			/Recursive orchestrator extension source/,
+			extension,
+		);
+	}
+});
+
+test("applyLaunchPolicy allows a non-self extension alongside compiled-layout protection", () => {
+	const extension = resolve(process.cwd(), "dist/extensions/custom-provider.js");
+	const profile = { ...resolveProfile("reviewer"), extensions: [extension] };
+	const plan = applyLaunchPolicy({ cwd: process.cwd(), profile });
+	assert.deepEqual(plan.workerExtensions, [extension]);
 });

--- a/tests/safety/self-extension.test.ts
+++ b/tests/safety/self-extension.test.ts
@@ -1,0 +1,103 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import {
+	getOrchestratorSelfEntryPaths,
+	isRecursiveOrchestratorExtensionSource,
+} from "../../src/safety/self-extension.js";
+
+function createLayout(prefix: string): string {
+	return mkdtempSync(join(tmpdir(), prefix));
+}
+
+test("self-entry candidates cover source and compiled layouts without a generated dist dependency", () => {
+	const root = createLayout("pi-agent-team-layout-");
+	const sourceModule = join(root, "src/safety/self-extension.ts");
+	const compiledModule = join(root, "dist/src/safety/self-extension.js");
+	const expected = [
+		join(root, "extensions/index.ts"),
+		join(root, "extensions/pi-agent-team/index.ts"),
+		join(root, "dist/extensions/index.js"),
+		join(root, "dist/extensions/pi-agent-team/index.js"),
+	];
+
+	for (const modulePath of [sourceModule, compiledModule]) {
+		const candidates = getOrchestratorSelfEntryPaths(modulePath);
+		for (const entrypoint of expected) assert.ok(candidates.has(entrypoint), `${modulePath}: ${entrypoint}`);
+	}
+});
+
+test("a source package root named dist is not mistaken for compiled output", () => {
+	const parent = createLayout("pi-agent-team-dist-collision-");
+	const packageRoot = join(parent, "dist");
+	const sourceModule = join(packageRoot, "src/safety/self-extension.ts");
+	const sourceEntry = join(packageRoot, "extensions/index.ts");
+	const compiledEntry = join(packageRoot, "dist/extensions/index.js");
+
+	for (const modulePath of [sourceModule, pathToFileURL(sourceModule).href]) {
+		const candidates = getOrchestratorSelfEntryPaths(modulePath);
+		assert.ok(candidates.has(sourceEntry), `${modulePath}: source entry`);
+		assert.ok(candidates.has(compiledEntry), `${modulePath}: compiled entry`);
+		assert.equal(isRecursiveOrchestratorExtensionSource(sourceEntry, packageRoot, modulePath), true, modulePath);
+		assert.equal(
+			isRecursiveOrchestratorExtensionSource(join(packageRoot, "extensions/provider.ts"), packageRoot, modulePath),
+			false,
+			modulePath,
+		);
+	}
+});
+
+test("source, built, and packed self entries are rejected while non-self extensions remain allowed", () => {
+	const checkout = createLayout("pi-agent-team-checkout-");
+	const packedRoot = join(checkout, "installed/node_modules/pi-agents-team");
+	const cases = [
+		{
+			modulePath: join(checkout, "src/safety/self-extension.ts"),
+			baseDir: checkout,
+			sources: [
+				"./extensions/index.ts",
+				"./dist/extensions/index.js",
+				"./dist/extensions/../extensions/pi-agent-team/index.js",
+			],
+		},
+		{
+			modulePath: join(checkout, "dist/src/safety/self-extension.js"),
+			baseDir: checkout,
+			sources: ["./dist/extensions/index.js", resolve(checkout, "dist/extensions/pi-agent-team/index.js")],
+		},
+		{
+			modulePath: join(packedRoot, "dist/src/safety/self-extension.js"),
+			baseDir: join(checkout, "consumer"),
+			sources: [join(packedRoot, "dist/extensions/index.js"), join(packedRoot, "dist/extensions/pi-agent-team/index.js")],
+		},
+	];
+
+	for (const { modulePath, baseDir, sources } of cases) {
+		for (const source of sources) {
+			assert.equal(isRecursiveOrchestratorExtensionSource(source, baseDir, modulePath), true, `${modulePath}: ${source}`);
+		}
+		assert.equal(
+			isRecursiveOrchestratorExtensionSource("./extensions/custom-provider.ts", baseDir, modulePath),
+			false,
+			modulePath,
+		);
+	}
+});
+
+test("self-entry detection follows symlinks in a compiled package layout", () => {
+	const root = createLayout("pi-agent-team-symlink-");
+	const modulePath = join(root, "dist/src/safety/self-extension.js");
+	const entrypoint = join(root, "dist/extensions/index.js");
+	const consumer = join(root, "consumer");
+	const linkedEntry = join(consumer, "linked-extension.js");
+	mkdirSync(resolve(entrypoint, ".."), { recursive: true });
+	mkdirSync(consumer, { recursive: true });
+	writeFileSync(entrypoint, "export default () => {};\n");
+	symlinkSync(entrypoint, linkedEntry, "file");
+
+	assert.equal(isRecursiveOrchestratorExtensionSource(linkedEntry, consumer, modulePath), true);
+	assert.equal(isRecursiveOrchestratorExtensionSource(join(consumer, "other-extension.js"), consumer, modulePath), false);
+});

--- a/tests/types/thinking-level-drift.test.ts
+++ b/tests/types/thinking-level-drift.test.ts
@@ -3,16 +3,15 @@ import assert from "node:assert/strict";
 import { existsSync, readFileSync } from "node:fs";
 import { THINKING_LEVELS } from "../../src/types";
 
-const CURRENT_LOCAL_THINKING_LEVELS = ["off", "minimal", "low", "medium", "high", "xhigh"] as const;
-const PI_0806_UPSTREAM_THINKING_LEVELS = [...CURRENT_LOCAL_THINKING_LEVELS, "max"] as const;
+const PI_0806_THINKING_LEVELS = ["off", "minimal", "low", "medium", "high", "xhigh", "max"] as const;
 
 const upstreamTypesCandidates = [
 	"node_modules/@earendil-works/pi-agent-core/dist/types.d.ts",
 	"node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-agent-core/dist/types.d.ts",
 ];
 
-test("local ThinkingLevel stays unchanged until the max compatibility task", () => {
-	assert.deepEqual(THINKING_LEVELS, CURRENT_LOCAL_THINKING_LEVELS);
+test("local ThinkingLevel matches the Pi 0.80.6 contract", () => {
+	assert.deepEqual(THINKING_LEVELS, PI_0806_THINKING_LEVELS);
 });
 
 test("upstream ThinkingLevel stays locked to the Pi 0.80.6 contract", () => {
@@ -23,6 +22,6 @@ test("upstream ThinkingLevel stays locked to the Pi 0.80.6 contract", () => {
 	assert.ok(match, "upstream ThinkingLevel declaration must be exported");
 	assert.deepEqual(
 		[...match[1].matchAll(/"([^"]+)"/g)].map((entry) => entry[1]),
-		PI_0806_UPSTREAM_THINKING_LEVELS,
+		PI_0806_THINKING_LEVELS,
 	);
 });

--- a/tests/types/thinking-level-drift.test.ts
+++ b/tests/types/thinking-level-drift.test.ts
@@ -10,7 +10,7 @@ type Exact<A, B> =
 			: false
 		: false;
 
-type Pi0806ThinkingLevel = "off" | "minimal" | "low" | "medium" | "high" | "xhigh";
+type Pi0806ThinkingLevel = "off" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max";
 
 const localThinkingLevelDriftCheck: Exact<ThinkingLevel, Pi0806ThinkingLevel> = true;
 const upstreamThinkingLevelDriftCheck: Exact<UpstreamThinkingLevel, Pi0806ThinkingLevel> = true;

--- a/tests/types/thinking-level-drift.test.ts
+++ b/tests/types/thinking-level-drift.test.ts
@@ -10,8 +10,12 @@ type Exact<A, B> =
 			: false
 		: false;
 
-const thinkingLevelDriftCheck: Exact<ThinkingLevel, UpstreamThinkingLevel> = true;
+type Pi0806ThinkingLevel = "off" | "minimal" | "low" | "medium" | "high" | "xhigh";
 
-test("local ThinkingLevel stays in lockstep with Pi upstream", () => {
-	assert.equal(thinkingLevelDriftCheck, true);
+const localThinkingLevelDriftCheck: Exact<ThinkingLevel, Pi0806ThinkingLevel> = true;
+const upstreamThinkingLevelDriftCheck: Exact<UpstreamThinkingLevel, Pi0806ThinkingLevel> = true;
+
+test("local and upstream ThinkingLevel stay locked to the Pi 0.80.6 contract", () => {
+	assert.equal(localThinkingLevelDriftCheck, true);
+	assert.equal(upstreamThinkingLevelDriftCheck, true);
 });

--- a/tests/types/thinking-level-drift.test.ts
+++ b/tests/types/thinking-level-drift.test.ts
@@ -1,21 +1,27 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import type { ThinkingLevel as UpstreamThinkingLevel } from "@earendil-works/pi-agent-core";
-import type { ThinkingLevel } from "../../src/types";
+import { existsSync, readFileSync } from "node:fs";
+import { THINKING_LEVELS } from "../../src/types";
 
-type Exact<A, B> =
-	(<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2)
-		? (<T>() => T extends B ? 1 : 2) extends (<T>() => T extends A ? 1 : 2)
-			? true
-			: false
-		: false;
+const PI_0806_THINKING_LEVELS = ["off", "minimal", "low", "medium", "high", "xhigh", "max"] as const;
 
-type Pi0806ThinkingLevel = "off" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max";
+const upstreamTypesCandidates = [
+	"node_modules/@earendil-works/pi-agent-core/dist/types.d.ts",
+	"node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-agent-core/dist/types.d.ts",
+];
 
-const localThinkingLevelDriftCheck: Exact<ThinkingLevel, Pi0806ThinkingLevel> = true;
-const upstreamThinkingLevelDriftCheck: Exact<UpstreamThinkingLevel, Pi0806ThinkingLevel> = true;
+test("local ThinkingLevel stays locked to the Pi 0.80.6 contract", () => {
+	assert.deepEqual(THINKING_LEVELS, PI_0806_THINKING_LEVELS);
+});
 
-test("local and upstream ThinkingLevel stay locked to the Pi 0.80.6 contract", () => {
-	assert.equal(localThinkingLevelDriftCheck, true);
-	assert.equal(upstreamThinkingLevelDriftCheck, true);
+test("upstream ThinkingLevel stays locked to the Pi 0.80.6 contract", () => {
+	const typesPath = upstreamTypesCandidates.find(existsSync);
+	assert.ok(typesPath, "installed Pi agent-core type declarations must be present");
+	const declaration = readFileSync(typesPath, "utf8");
+	const match = declaration.match(/export type ThinkingLevel = ([^;]+);/);
+	assert.ok(match, "upstream ThinkingLevel declaration must be exported");
+	assert.deepEqual(
+		[...match[1].matchAll(/"([^"]+)"/g)].map((entry) => entry[1]),
+		PI_0806_THINKING_LEVELS,
+	);
 });

--- a/tests/types/thinking-level-drift.test.ts
+++ b/tests/types/thinking-level-drift.test.ts
@@ -3,15 +3,16 @@ import assert from "node:assert/strict";
 import { existsSync, readFileSync } from "node:fs";
 import { THINKING_LEVELS } from "../../src/types";
 
-const PI_0806_THINKING_LEVELS = ["off", "minimal", "low", "medium", "high", "xhigh", "max"] as const;
+const CURRENT_LOCAL_THINKING_LEVELS = ["off", "minimal", "low", "medium", "high", "xhigh"] as const;
+const PI_0806_UPSTREAM_THINKING_LEVELS = [...CURRENT_LOCAL_THINKING_LEVELS, "max"] as const;
 
 const upstreamTypesCandidates = [
 	"node_modules/@earendil-works/pi-agent-core/dist/types.d.ts",
 	"node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-agent-core/dist/types.d.ts",
 ];
 
-test("local ThinkingLevel stays locked to the Pi 0.80.6 contract", () => {
-	assert.deepEqual(THINKING_LEVELS, PI_0806_THINKING_LEVELS);
+test("local ThinkingLevel stays unchanged until the max compatibility task", () => {
+	assert.deepEqual(THINKING_LEVELS, CURRENT_LOCAL_THINKING_LEVELS);
 });
 
 test("upstream ThinkingLevel stays locked to the Pi 0.80.6 contract", () => {
@@ -22,6 +23,6 @@ test("upstream ThinkingLevel stays locked to the Pi 0.80.6 contract", () => {
 	assert.ok(match, "upstream ThinkingLevel declaration must be exported");
 	assert.deepEqual(
 		[...match[1].matchAll(/"([^"]+)"/g)].map((entry) => entry[1]),
-		PI_0806_THINKING_LEVELS,
+		PI_0806_UPSTREAM_THINKING_LEVELS,
 	);
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "module": "ESNext",
-    "moduleResolution": "Bundler",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
     "strict": true,
     "noEmit": true,
     "skipLibCheck": true,

--- a/tsconfig.publish.json
+++ b/tsconfig.publish.json
@@ -1,0 +1,21 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "declaration": true,
+    "declarationMap": false,
+    "outDir": "dist",
+    "rootDir": ".",
+    "verbatimModuleSyntax": true,
+    "isolatedModules": true,
+    "noEmitOnError": true
+  },
+  "include": [
+    "src/**/*.ts",
+    "extensions/**/*.ts"
+  ],
+  "exclude": [
+    "tests/**/*.ts",
+    "**/*.test.ts"
+  ]
+}


### PR DESCRIPTION
## Feature Description

Publish `pi-agents-team` as native ESM JavaScript with declarations and validate the Pi executable before any worker process starts. Installed consumers now load `dist/extensions/index.js` instead of relying on TypeScript source or local `jiti` behavior.

## User Story

As a package consumer, I want the installed extension to load compiled output and reject incompatible worker runtimes before launch so that npm installs behave the same as local development.

## Type of Change

- [x] New feature

## Implementation Details

- Add a NodeNext publish build that compiles JavaScript and `.d.ts` files, then copies prompts and profiles into ignored `dist/` output.
- Point package exports and `pi.extensions` at the compiled entrypoint while retaining the source shim for local development.
- Add explicit `.js` specifiers across internal ESM imports and strengthen self-extension checks for both source and compiled layouts.
- Require Node.js `>=22.19.0` and Pi peer compatibility `>=0.80.6`.
- Probe the resolved worker Pi command before RPC spawn. Reject missing, malformed, timed-out, or `<0.80.6` versions; warn once for supported host/worker mismatches.
- Accept the Pi `max` thinking level without changing built-in role defaults.

### Architecture

The package entrypoint remains `extensions/index.ts` in source and becomes `dist/extensions/index.js` after build. `WorkerManager` performs compatibility preflight before `spawnWorkerProcess`, so unsupported workers never reserve a live RPC process.

### Key Files Changed

| File | Change |
|------|--------|
| `package.json` | Define compiled exports, package files, Node/Pi requirements, and publish hooks. |
| `scripts/build-publish.mjs` | Compile JavaScript/declarations and copy package assets. |
| `tsconfig.publish.json` | Configure the NodeNext declaration build. |
| `src/runtime/pi-version.ts` | Parse and probe worker Pi versions. |
| `src/runtime/worker-manager.ts` | Gate worker spawn on compatibility preflight. |
| `src/safety/self-extension.ts` | Detect source and compiled self-extension paths. |

## API Changes

| Method | Endpoint | Description |
|--------|----------|-------------|
| Package import | `pi-agents-team` | Resolves to compiled ESM JavaScript with declarations. |
| Pi extension load | `pi.extensions` | Loads `./dist/extensions/index.js`. |
| Worker launch | Pi RPC command | Requires a parseable worker Pi version `>=0.80.6` before spawn. |
| Thinking level | `max` | Accepted and passed through to Pi. |

## Database Changes

- [x] No database changes
- [ ] Migration included and tested

## How to Test

1. Run `npm ci`.
2. Run `npm run check`.
3. Run `npm run build` and inspect ignored `dist/` output or package it with `npm pack`.

Verified on this branch:

- `npm run check`: 443 passed, 0 failed.
- `npm run build`: completed successfully.

### Edge Cases Considered

- Source checkout versus compiled package paths.
- Wrapper commands and explicit Pi CLI entrypoint prefixes.
- Missing, malformed, prerelease, timed-out, old, or supported-mismatch Pi versions.
- Model-dependent clamping of `max` thinking.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-reviewed the code
- [x] Added unit tests for new functionality
- [x] Added integration tests where applicable
- [x] Existing tests pass locally
- [x] Updated documentation
- [ ] Tested on mobile (not applicable: terminal extension)
- [x] No new warnings or console errors introduced
- [x] Backwards compatible (or migration plan documented)

## Feature Flag

- [x] No feature flag needed
- [ ] Behind feature flag: `FLAG_NAME`

## Related Issues

None found in the branch name or commit history.

## Screenshots / Demo

Not applicable. This changes package and runtime behavior, not a browser UI.

## Deployment Notes

- Requires Node.js `>=22.19.0` and worker Pi `>=0.80.6`.
- `prepack` runs the publish build; generated `dist/` output remains ignored.

## Stack

1 of 5. Base: `main`. The next PR is `fix/worker-settlement-runtime`.
