### PR TITLE
Harden package and Pi probe contracts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,3 @@ coverage/
 .DS_Store
 *.log
 bun.lock
-.slim/deepwork/

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ coverage/
 .DS_Store
 *.log
 bun.lock
+.slim/deepwork/

--- a/.ignore
+++ b/.ignore
@@ -1,0 +1,2 @@
+!.slim/deepwork/
+!.slim/deepwork/**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Thanks for helping out. This guide covers local setup, the test discipline, and 
 
 ## Local setup
 
-Use Node `>=22.19.0`. Development validation uses exactly Pi `0.80.7`, while the supported host and worker minimum remains Pi `>=0.80.6`. npm and `package-lock.json` are the only supported dependency and lock workflow; do not add or regenerate a Bun lock.
+Use Node `>=22.19.0`. Development validation uses exactly Pi `0.80.6`, which is also the supported host and worker minimum. npm and `package-lock.json` are the only supported dependency and lock workflow; do not add or regenerate a Bun lock.
 
 ```bash
 git clone git@github.com:KristjanPikhof/pi-agents-team.git
@@ -13,14 +13,23 @@ npm install
 npm run check            # typecheck + all tests, must be green before you push
 ```
 
-Run the extension against your working copy without going through `pi install`:
+Run the source shim against your working copy without going through `pi install`:
 
 ```bash
 pi -e ./extensions/index.ts
-pi -e ./extensions/index.ts -p "/team"   # open straight into the dashboard
 ```
 
-This is the local-development path. Pi loads `extensions/index.ts` through `jiti`; installed consumers use the compiled npm package instead. Direct Git package installs are not supported because `dist/` is ignored and Pi's Git install flow does not build it.
+This checks the local-development path. Pi loads `extensions/index.ts` through `jiti`; it does not check the compiled or published package entrypoint. To exercise the TUI overlay, start Pi interactively and enter `/team`. Do not use `-p "/team"` as an overlay check: `-p` submits a prompt and does not exercise interactive overlay input or rendering.
+
+Validate the compiled and published paths separately:
+
+```bash
+npm run build
+pi -e ./dist/extensions/index.js
+npx tsx --test tests/package-manifest.test.ts tests/package-publish.test.ts
+```
+
+Installed consumers use the compiled npm package. The focused package tests check the `dist/` manifest contract, pack the package, install it offline, and import it from a clean consumer. Direct Git package installs are not supported because `dist/` is ignored and Pi's Git install flow does not build it.
 
 ## Commands
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,14 @@ npm install
 pi -e ./extensions/index.ts
 ```
 
-Pi loads this local-development shim through `jiti`, so a build is not required before each run. Use `npm run build` when you need to inspect or validate the compiled package output in `dist/`.
+Pi loads this local-development shim through `jiti`, so a build is not required before each run. This checks the source path only; it does not validate the compiled or published package entrypoint. Validate those paths separately:
+
+```bash
+npm run build
+npx tsx --test tests/package-manifest.test.ts tests/package-publish.test.ts
+```
+
+The focused package tests check the `dist/` manifest contract, run `npm pack`, install the tarball offline, and import it from a clean consumer.
 
 ## Operator commands
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -116,7 +116,7 @@ Workers run through `pi --mode rpc --no-session`. That gives us prompt, steer, f
 The probe keeps a promise cache keyed by the resolved command and any CLI entrypoint prefix. Concurrent first launches share that promise, and later launches reuse the result rather than spawning another version check. This applies to the default and custom worker commands, so injected test launchers must also inject a probe and never fall through to a machine-global `pi`.
 
 Exact host/worker patch equality is not required. A supported worker version that differs from the host emits one non-fatal warning per extension session; an exact match emits none. This is a minimum-version gate, not an upper-bound policy.
-Repository development dependencies and validation use exactly Pi `0.80.7`. That tested version does not raise the supported host or worker minimum: both remain Pi `>=0.80.6`.
+Repository development dependencies and validation use exactly Pi `0.80.6`, the same release as the supported host and worker minimum.
 
 ### Workers launch with reduced discovery
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -2,7 +2,7 @@
 
 ## Quick start
 
-Requires Node `>=22.19.0`. Development validation uses exactly Pi `0.80.7`, while supported hosts and workers retain a Pi `>=0.80.6` minimum. Use npm and `package-lock.json` as the authoritative dependency and lock workflow.
+Requires Node `>=22.19.0`. Development validation uses exactly Pi `0.80.6`, which is also the supported host and worker minimum. Use npm and `package-lock.json` as the authoritative dependency and lock workflow.
 
 Install dependencies and run the checks:
 
@@ -19,10 +19,17 @@ npm run smoke:runtime
 npm run smoke:team
 ```
 
-Load the extension directly:
+Load the source shim for a local-development check:
 
 ```bash
 pi -e ./extensions/index.ts
+```
+
+This command does not validate the compiled or published package entrypoint. Run the focused package checks for that contract:
+
+```bash
+npm run build
+npx tsx --test tests/package-manifest.test.ts tests/package-publish.test.ts
 ```
 
 **Large-session warning:** This release does not repair existing multi-gigabyte legacy sessions. They may be unsafe to resume. Start a genuinely new session instead, or migrate the JSONL offline while Pi is stopped.
@@ -573,10 +580,23 @@ Fixed. The `starting → idle` race has a guard in `applyNormalizedEvent` (worke
 
 ## Local verification commands
 
+Check the source shim during development:
+
 ```bash
-npm run typecheck
-npm test
-pi -e ./extensions/index.ts -p "/team"
+pi -e ./extensions/index.ts
 ```
 
-That smoke command exercises the shipped package entrypoint in the same mode operators use: an overlay-style, keyboard-first panel in TUI environments, with a compact text fallback when no UI is available.
+Check the compiled Pi entrypoint:
+
+```bash
+npm run build
+pi -e ./dist/extensions/index.js
+```
+
+Check the published package contract by packing, installing offline, and importing from a clean consumer:
+
+```bash
+npx tsx --test tests/package-manifest.test.ts tests/package-publish.test.ts
+```
+
+For a manual TUI overlay check, start either Pi entrypoint interactively and enter `/team` after Pi opens. Do not use `-p "/team"` as evidence for overlay behavior: `-p` submits a prompt and does not exercise interactive overlay input or rendering.

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,8 +13,8 @@
         "typebox": "^1.0.56"
       },
       "devDependencies": {
-        "@earendil-works/pi-coding-agent": "0.80.7",
-        "@earendil-works/pi-tui": "0.80.7",
+        "@earendil-works/pi-coding-agent": "0.80.6",
+        "@earendil-works/pi-tui": "0.80.6",
         "@types/node": "^25.6.0",
         "tsx": "^4.22.4",
         "typescript": "^6.0.3"
@@ -28,16 +28,16 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent": {
-      "version": "0.80.7",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.80.7.tgz",
-      "integrity": "sha512-mxq3IClhdgmCrYiKuzKehs4QKCVJgKmlA70nUEzsgeNsGdxriT7o5sKQTCcxzVJkzDRMcHD/8tAP4/eGrV4gKQ==",
+      "version": "0.80.6",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.80.6.tgz",
+      "integrity": "sha512-vcfD6tOk402isLl3Cm/qbn2O10TvgroMp1+/fEGM24ZdvETFCdOYv5VZ7m59EI5fPsjfSJh+CpQ5bhBrhfOg7g==",
       "dev": true,
       "hasShrinkwrap": true,
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-agent-core": "^0.80.7",
-        "@earendil-works/pi-ai": "^0.80.7",
-        "@earendil-works/pi-tui": "^0.80.7",
+        "@earendil-works/pi-agent-core": "^0.80.6",
+        "@earendil-works/pi-ai": "^0.80.6",
+        "@earendil-works/pi-tui": "^0.80.6",
         "@silvia-odwyer/photon-node": "0.3.4",
         "chalk": "5.6.2",
         "cross-spawn": "7.0.6",
@@ -527,12 +527,12 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-agent-core": {
-      "version": "0.80.7",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.80.7.tgz",
+      "version": "0.80.6",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.80.6.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-ai": "^0.80.7",
+        "@earendil-works/pi-ai": "^0.80.6",
         "ignore": "7.0.5",
         "typebox": "1.1.38",
         "yaml": "2.9.0"
@@ -542,8 +542,8 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-ai": {
-      "version": "0.80.7",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.80.7.tgz",
+      "version": "0.80.6",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.80.6.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -567,8 +567,8 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-tui": {
-      "version": "0.80.7",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.80.7.tgz",
+      "version": "0.80.6",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.80.6.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2001,9 +2001,9 @@
       }
     },
     "node_modules/@earendil-works/pi-tui": {
-      "version": "0.80.7",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.80.7.tgz",
-      "integrity": "sha512-1B2++fLZfgI3XMzW2BTpuDuam2uyHnUUEmsOvi5R0Ne9RAt59WjFV0G8ozX6l1Xafa9P5Y3eT4aDtRr/v/CUTA==",
+      "version": "0.80.6",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.80.6.tgz",
+      "integrity": "sha512-bSuzS4EVSqEPj/Qr/p9eqCESfKsGuDNbl77EGci8Iaqqt/C/XCBZL1MjXaxSWW1NsT5afjp/Cb0NTPzOLv/aPA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,8 +13,8 @@
         "typebox": "^1.0.56"
       },
       "devDependencies": {
-        "@earendil-works/pi-coding-agent": "0.80.6",
-        "@earendil-works/pi-tui": "0.80.6",
+        "@earendil-works/pi-coding-agent": "0.80.7",
+        "@earendil-works/pi-tui": "0.80.7",
         "@types/node": "^25.6.0",
         "tsx": "^4.22.4",
         "typescript": "^6.0.3"
@@ -28,16 +28,16 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent": {
-      "version": "0.80.6",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.80.6.tgz",
-      "integrity": "sha512-vcfD6tOk402isLl3Cm/qbn2O10TvgroMp1+/fEGM24ZdvETFCdOYv5VZ7m59EI5fPsjfSJh+CpQ5bhBrhfOg7g==",
+      "version": "0.80.7",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.80.7.tgz",
+      "integrity": "sha512-mxq3IClhdgmCrYiKuzKehs4QKCVJgKmlA70nUEzsgeNsGdxriT7o5sKQTCcxzVJkzDRMcHD/8tAP4/eGrV4gKQ==",
       "dev": true,
       "hasShrinkwrap": true,
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-agent-core": "^0.80.6",
-        "@earendil-works/pi-ai": "^0.80.6",
-        "@earendil-works/pi-tui": "^0.80.6",
+        "@earendil-works/pi-agent-core": "^0.80.7",
+        "@earendil-works/pi-ai": "^0.80.7",
+        "@earendil-works/pi-tui": "^0.80.7",
         "@silvia-odwyer/photon-node": "0.3.4",
         "chalk": "5.6.2",
         "cross-spawn": "7.0.6",
@@ -527,12 +527,12 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-agent-core": {
-      "version": "0.80.6",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.80.6.tgz",
+      "version": "0.80.7",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.80.7.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-ai": "^0.80.6",
+        "@earendil-works/pi-ai": "^0.80.7",
         "ignore": "7.0.5",
         "typebox": "1.1.38",
         "yaml": "2.9.0"
@@ -542,8 +542,8 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-ai": {
-      "version": "0.80.6",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.80.6.tgz",
+      "version": "0.80.7",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.80.7.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -567,8 +567,8 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-tui": {
-      "version": "0.80.6",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.80.6.tgz",
+      "version": "0.80.7",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.80.7.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2001,9 +2001,9 @@
       }
     },
     "node_modules/@earendil-works/pi-tui": {
-      "version": "0.80.6",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.80.6.tgz",
-      "integrity": "sha512-bSuzS4EVSqEPj/Qr/p9eqCESfKsGuDNbl77EGci8Iaqqt/C/XCBZL1MjXaxSWW1NsT5afjp/Cb0NTPzOLv/aPA==",
+      "version": "0.80.7",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.80.7.tgz",
+      "integrity": "sha512-1B2++fLZfgI3XMzW2BTpuDuam2uyHnUUEmsOvi5R0Ne9RAt59WjFV0G8ozX6l1Xafa9P5Y3eT4aDtRr/v/CUTA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -75,8 +75,8 @@
     "@earendil-works/pi-tui": ">=0.80.6"
   },
   "devDependencies": {
-    "@earendil-works/pi-coding-agent": "0.80.6",
-    "@earendil-works/pi-tui": "0.80.6",
+    "@earendil-works/pi-coding-agent": "0.80.7",
+    "@earendil-works/pi-tui": "0.80.7",
     "@types/node": "^25.6.0",
     "tsx": "^4.22.4",
     "typescript": "^6.0.3"

--- a/package.json
+++ b/package.json
@@ -75,8 +75,8 @@
     "@earendil-works/pi-tui": ">=0.80.6"
   },
   "devDependencies": {
-    "@earendil-works/pi-coding-agent": "0.80.7",
-    "@earendil-works/pi-tui": "0.80.7",
+    "@earendil-works/pi-coding-agent": "0.80.6",
+    "@earendil-works/pi-tui": "0.80.6",
     "@types/node": "^25.6.0",
     "tsx": "^4.22.4",
     "typescript": "^6.0.3"

--- a/src/runtime/pi-version.ts
+++ b/src/runtime/pi-version.ts
@@ -11,7 +11,7 @@ const crossSpawn = require("cross-spawn") as typeof nodeSpawn;
 export const HOST_PI_VERSION = VERSION;
 export const MINIMUM_WORKER_PI_VERSION = "0.80.6";
 const DEFAULT_PROBE_TIMEOUT_MS = 5_000;
-const SUCCESSFUL_PROBE_CACHE_TTL_MS = 30_000;
+export const SUCCESSFUL_PROBE_CACHE_TTL_MS = 30_000;
 const PROBE_OUTPUT_LIMIT_BYTES = 64 * 1024;
 const DIAGNOSTIC_LIMIT_CHARS = 500;
 
@@ -330,7 +330,6 @@ export async function probeWorkerPiVersion(
 	}
 	if (existing) probeCache.delete(key);
 
-	const entry: ProbeCacheEntry = { promise: undefined as unknown as Promise<PiVersionProbeResult> };
 	const pending = (async (): Promise<PiVersionProbeResult> => {
 		const common = {
 			command,
@@ -382,7 +381,7 @@ export async function probeWorkerPiVersion(
 			}),
 		};
 	})();
-	entry.promise = pending;
+	const entry: ProbeCacheEntry = { promise: pending };
 	probeCache.set(key, entry);
 	const result = await pending;
 	if (probeCache.get(key) === entry) {

--- a/src/runtime/pi-version.ts
+++ b/src/runtime/pi-version.ts
@@ -1,5 +1,6 @@
 import { spawn as nodeSpawn } from "node:child_process";
-import { existsSync } from "node:fs";
+import { createHash } from "node:crypto";
+import { existsSync, statSync } from "node:fs";
 import { createRequire } from "node:module";
 import { basename, delimiter, extname, isAbsolute, resolve } from "node:path";
 import { VERSION } from "@earendil-works/pi-coding-agent";
@@ -10,6 +11,7 @@ const crossSpawn = require("cross-spawn") as typeof nodeSpawn;
 export const HOST_PI_VERSION = VERSION;
 export const MINIMUM_WORKER_PI_VERSION = "0.80.6";
 const DEFAULT_PROBE_TIMEOUT_MS = 5_000;
+const SUCCESSFUL_PROBE_CACHE_TTL_MS = 30_000;
 const PROBE_OUTPUT_LIMIT_BYTES = 64 * 1024;
 const DIAGNOSTIC_LIMIT_CHARS = 500;
 
@@ -57,7 +59,12 @@ export interface PiVersionProbeResult {
 
 export type ProbeWorkerPiVersion = (options: PiVersionProbeOptions) => Promise<PiVersionProbeResult>;
 
-const probeCache = new Map<string, Promise<PiVersionProbeResult>>();
+interface ProbeCacheEntry {
+	promise: Promise<PiVersionProbeResult>;
+	completedAt?: number;
+}
+
+const probeCache = new Map<string, ProbeCacheEntry>();
 
 export function parsePiVersion(output: string): ParsedPiVersion | undefined {
 	const match = output.trim().match(
@@ -128,20 +135,34 @@ function executableCandidates(command: string, env: NodeJS.ProcessEnv): string[]
 	return [command, ...pathExt.split(";").filter(Boolean).map((extension) => `${command}${extension.toLowerCase()}`)];
 }
 
+function fingerprint(value: string): string {
+	return createHash("sha256").update(value).digest("hex");
+}
+
+function fileIdentity(path: string): string {
+	try {
+		const stat = statSync(path);
+		return `${path}\0file:${stat.dev}:${stat.ino}:${stat.size}:${stat.mtimeMs}:${stat.ctimeMs}`;
+	} catch {
+		return path;
+	}
+}
+
 function resolveCommandIdentity(command: string, cwd: string, suppliedEnv?: NodeJS.ProcessEnv): string {
 	const env = suppliedEnv ?? process.env;
 	if (isAbsolute(command) || command.includes("/") || command.includes("\\")) {
-		return resolve(cwd, command);
+		return fileIdentity(resolve(cwd, command));
 	}
 	const pathValue = environmentValue(env, "PATH") ?? (process.platform === "win32" ? "" : "/usr/bin:/bin");
 	for (const directory of pathValue.split(delimiter)) {
 		if (!directory) continue;
 		for (const candidate of executableCandidates(command, env)) {
 			const path = resolve(cwd, directory, candidate);
-			if (existsSync(path)) return path;
+			if (existsSync(path)) return fileIdentity(path);
 		}
 	}
-	return `unresolved:${command}\0cwd:${resolve(cwd)}\0path:${pathValue}`;
+	const pathExt = environmentValue(env, "PATHEXT") ?? "";
+	return `unresolved:${command}\0lookup:${fingerprint(`${cwd}\0${pathValue}\0${pathExt}`)}`;
 }
 
 function environmentIdentity(suppliedEnv?: NodeJS.ProcessEnv): string {
@@ -151,12 +172,13 @@ function environmentIdentity(suppliedEnv?: NodeJS.ProcessEnv): string {
 		if (value === undefined) return [];
 		return [[process.platform === "win32" ? key.toLowerCase() : key, value] as const];
 	});
-	return JSON.stringify(entries);
+	return fingerprint(JSON.stringify(entries));
 }
 
-function commandCacheKey(command: string, args: string[], cwd: string, env?: NodeJS.ProcessEnv): string {
+export function buildPiVersionProbeCacheKey(command: string, args: string[], cwd: string, env?: NodeJS.ProcessEnv): string {
 	const resolvedCwd = resolve(cwd);
-	return `${resolveCommandIdentity(command, resolvedCwd, env)}\0cwd:${resolvedCwd}\0env:${environmentIdentity(env)}\0${args.join("\0")}`;
+	const invocationIdentity = fingerprint(JSON.stringify({ args, environment: environmentIdentity(env) }));
+	return `${resolveCommandIdentity(command, resolvedCwd, env)}\0cwd:${resolvedCwd}\0invocation:${invocationIdentity}`;
 }
 
 function appendCapped(current: string, chunk: unknown): string {
@@ -190,23 +212,61 @@ function signalProcessGroup(pid: number | undefined, child: ReturnType<typeof no
 	}
 }
 
+interface KillableChild {
+	pid?: number;
+	kill(signal?: NodeJS.Signals): boolean;
+}
+
+type TaskkillSpawn = (command: string, args: string[], options: { stdio: "ignore" }) => KillableChild & {
+	once(event: "error", listener: () => void): unknown;
+	once(event: "close", listener: (code: number | null) => void): unknown;
+};
+
+function tryKill(child: KillableChild): void {
+	try {
+		child.kill();
+	} catch {
+		// The process may already have exited.
+	}
+}
+
+export async function terminateWindowsProcessTree(
+	child: KillableChild,
+	spawnTaskkill: TaskkillSpawn = crossSpawn as unknown as TaskkillSpawn,
+	timeoutMs = 500,
+): Promise<void> {
+	if (child.pid === undefined) {
+		tryKill(child);
+		return;
+	}
+	await new Promise<void>((resolveTermination) => {
+		let killer: ReturnType<TaskkillSpawn> | undefined;
+		let settled = false;
+		const finish = (fallback: boolean) => {
+			if (settled) return;
+			settled = true;
+			clearTimeout(timeout);
+			if (fallback) tryKill(child);
+			resolveTermination();
+		};
+		const timeout = setTimeout(() => {
+			if (killer) tryKill(killer);
+			finish(true);
+		}, timeoutMs);
+		timeout.unref?.();
+		try {
+			killer = spawnTaskkill("taskkill", ["/pid", String(child.pid), "/T", "/F"], { stdio: "ignore" });
+			killer.once("error", () => finish(true));
+			killer.once("close", (code) => finish(code !== 0));
+		} catch {
+			finish(true);
+		}
+	});
+}
+
 async function terminateProcessTree(child: ReturnType<typeof nodeSpawn>): Promise<void> {
 	if (process.platform === "win32") {
-		if (child.pid === undefined) {
-			child.kill();
-			return;
-		}
-		await Promise.race([
-			new Promise<void>((resolveTaskkill) => {
-				const killer = crossSpawn("taskkill", ["/pid", String(child.pid), "/T", "/F"], { stdio: "ignore" });
-				killer.once("error", () => {
-					child.kill();
-					resolveTaskkill();
-				});
-				killer.once("close", () => resolveTaskkill());
-			}),
-			delay(500),
-		]);
+		await terminateWindowsProcessTree(child);
 		return;
 	}
 
@@ -263,10 +323,14 @@ export async function probeWorkerPiVersion(
 ): Promise<PiVersionProbeResult> {
 	const command = options.command ?? "pi";
 	const versionArgs = buildPiVersionArgs(options.baseArgs);
-	const key = commandCacheKey(command, versionArgs, options.cwd, options.env);
+	const key = buildPiVersionProbeCacheKey(command, versionArgs, options.cwd, options.env);
 	const existing = probeCache.get(key);
-	if (existing) return existing;
+	if (existing && (existing.completedAt === undefined || Date.now() - existing.completedAt < SUCCESSFUL_PROBE_CACHE_TTL_MS)) {
+		return existing.promise;
+	}
+	if (existing) probeCache.delete(key);
 
+	const entry: ProbeCacheEntry = { promise: undefined as unknown as Promise<PiVersionProbeResult> };
 	const pending = (async (): Promise<PiVersionProbeResult> => {
 		const common = {
 			command,
@@ -318,9 +382,13 @@ export async function probeWorkerPiVersion(
 			}),
 		};
 	})();
-	probeCache.set(key, pending);
+	entry.promise = pending;
+	probeCache.set(key, entry);
 	const result = await pending;
-	if (!result.supported && probeCache.get(key) === pending) probeCache.delete(key);
+	if (probeCache.get(key) === entry) {
+		if (result.supported) entry.completedAt = Date.now();
+		else probeCache.delete(key);
+	}
 	return result;
 }
 

--- a/src/runtime/pi-version.ts
+++ b/src/runtime/pi-version.ts
@@ -177,8 +177,13 @@ function environmentIdentity(suppliedEnv?: NodeJS.ProcessEnv): string {
 
 export function buildPiVersionProbeCacheKey(command: string, args: string[], cwd: string, env?: NodeJS.ProcessEnv): string {
 	const resolvedCwd = resolve(cwd);
-	const invocationIdentity = fingerprint(JSON.stringify({ args, environment: environmentIdentity(env) }));
-	return `${resolveCommandIdentity(command, resolvedCwd, env)}\0cwd:${resolvedCwd}\0invocation:${invocationIdentity}`;
+	const identity = JSON.stringify({
+		command: resolveCommandIdentity(command, resolvedCwd, env),
+		cwd: resolvedCwd,
+		args,
+		environment: environmentIdentity(env),
+	});
+	return `pi-version-probe:v1:${fingerprint(identity)}`;
 }
 
 function appendCapped(current: string, chunk: unknown): string {

--- a/tests/package-manifest.test.ts
+++ b/tests/package-manifest.test.ts
@@ -37,12 +37,12 @@ test("package manifest exposes only the compiled extension and dist-contained as
 	assert.ok(!packageJson.files?.includes("profiles"), "worker profiles ship under dist only");
 });
 
-test("package manifest pins the tested Pi development release", () => {
+test("package manifest pins development checks to the minimum supported Pi release", () => {
 	const testedPiVersions = {
 		codingAgent: packageJson.devDependencies?.["@earendil-works/pi-coding-agent"],
 		tui: packageJson.devDependencies?.["@earendil-works/pi-tui"],
 	};
-	assert.deepEqual(testedPiVersions, { codingAgent: "0.80.7", tui: "0.80.7" });
+	assert.deepEqual(testedPiVersions, { codingAgent: "0.80.6", tui: "0.80.6" });
 	assert.deepEqual(
 		{
 			codingAgent: packageLock.packages?.[""]?.devDependencies?.["@earendil-works/pi-coding-agent"],

--- a/tests/package-publish.test.ts
+++ b/tests/package-publish.test.ts
@@ -49,7 +49,15 @@ test("a clean publish artifact installs and imports in an offline consumer", { t
 
 		await writeFile(
 			join(consumer, "package.json"),
-			JSON.stringify({ name: "publish-contract-consumer", private: true, type: "module" }),
+			JSON.stringify({
+				name: "publish-contract-consumer",
+				private: true,
+				type: "module",
+				dependencies: {
+					"@earendil-works/pi-coding-agent": "0.80.6",
+					"@earendil-works/pi-tui": "0.80.6",
+				},
+			}),
 		);
 		const tarball = join(artifacts, tarballs[0]!);
 		runNpm(
@@ -67,6 +75,12 @@ test("a clean publish artifact installs and imports in an offline consumer", { t
 			version?: string;
 		};
 		assert.equal(installedManifest.version, sourceManifest.version);
+		for (const piPackage of ["pi-coding-agent", "pi-tui"]) {
+			const manifest = JSON.parse(
+				await readFile(join(consumer, "node_modules", "@earendil-works", piPackage, "package.json"), "utf8"),
+			) as { version?: string };
+			assert.equal(manifest.version, "0.80.6", `${piPackage} consumer baseline drifted`);
+		}
 
 		const imported = spawnSync(
 			process.execPath,

--- a/tests/package-publish.test.ts
+++ b/tests/package-publish.test.ts
@@ -7,7 +7,7 @@ import { basename, join, resolve } from "node:path";
 import { spawnSync } from "node:child_process";
 
 const projectRoot = resolve(import.meta.dirname, "..");
-const NPM_SUBPROCESS_TIMEOUT_MS = 45_000;
+const PACKAGE_SUBPROCESS_TIMEOUT_MS = 45_000;
 
 function runNpm(args: string[], cwd: string) {
 	const npmCli = process.env.npm_execpath;
@@ -17,12 +17,12 @@ function runNpm(args: string[], cwd: string) {
 		cwd,
 		encoding: "utf8",
 		env: { ...process.env, NO_UPDATE_NOTIFIER: "1" },
-		timeout: NPM_SUBPROCESS_TIMEOUT_MS,
+		timeout: PACKAGE_SUBPROCESS_TIMEOUT_MS,
 	});
 	assert.equal(
 		result.status,
 		0,
-		`npm ${args.join(" ")} failed (timeout=${NPM_SUBPROCESS_TIMEOUT_MS}ms; status=${String(result.status)}; signal=${String(result.signal)}; error=${result.error?.message ?? "none"})\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
+		`npm ${args.join(" ")} failed (timeout=${PACKAGE_SUBPROCESS_TIMEOUT_MS}ms; status=${String(result.status)}; signal=${String(result.signal)}; error=${result.error?.message ?? "none"})\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
 	);
 	return result;
 }
@@ -87,12 +87,12 @@ test("a clean publish artifact installs and imports in an offline consumer", { t
 		const imported = spawnSync(
 			process.execPath,
 			["--input-type=module", "--eval", 'import extension from "pi-agents-team"; if (typeof extension !== "function") process.exit(1)'],
-			{ cwd: consumer, encoding: "utf8" },
+			{ cwd: consumer, encoding: "utf8", timeout: PACKAGE_SUBPROCESS_TIMEOUT_MS },
 		);
 		assert.equal(
 			imported.status,
 			0,
-			`consumer import failed for ${basename(tarball)}\nstdout:\n${imported.stdout}\nstderr:\n${imported.stderr}`,
+			`consumer import failed for ${basename(tarball)} (timeout=${PACKAGE_SUBPROCESS_TIMEOUT_MS}ms; status=${String(imported.status)}; signal=${String(imported.signal)}; error=${imported.error?.message ?? "none"})\nstdout:\n${imported.stdout}\nstderr:\n${imported.stderr}`,
 		);
 	} finally {
 		await rm(temporaryRoot, { recursive: true, force: true });

--- a/tests/package-publish.test.ts
+++ b/tests/package-publish.test.ts
@@ -7,6 +7,7 @@ import { basename, join, resolve } from "node:path";
 import { spawnSync } from "node:child_process";
 
 const projectRoot = resolve(import.meta.dirname, "..");
+const NPM_SUBPROCESS_TIMEOUT_MS = 45_000;
 
 function runNpm(args: string[], cwd: string) {
 	const npmCli = process.env.npm_execpath;
@@ -16,11 +17,12 @@ function runNpm(args: string[], cwd: string) {
 		cwd,
 		encoding: "utf8",
 		env: { ...process.env, NO_UPDATE_NOTIFIER: "1" },
+		timeout: NPM_SUBPROCESS_TIMEOUT_MS,
 	});
 	assert.equal(
 		result.status,
 		0,
-		`npm ${args.join(" ")} failed\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
+		`npm ${args.join(" ")} failed (timeout=${NPM_SUBPROCESS_TIMEOUT_MS}ms; status=${String(result.status)}; signal=${String(result.signal)}; error=${result.error?.message ?? "none"})\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
 	);
 	return result;
 }

--- a/tests/package-publish.test.ts
+++ b/tests/package-publish.test.ts
@@ -1,0 +1,84 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { existsSync } from "node:fs";
+import { cp, mkdtemp, mkdir, readFile, readdir, rm, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { basename, join, resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+
+const projectRoot = resolve(import.meta.dirname, "..");
+
+function runNpm(args: string[], cwd: string) {
+	const npmCli = process.env.npm_execpath;
+	const command = npmCli ? process.execPath : process.platform === "win32" ? "npm.cmd" : "npm";
+	const commandArgs = npmCli ? [npmCli, ...args] : args;
+	const result = spawnSync(command, commandArgs, {
+		cwd,
+		encoding: "utf8",
+		env: { ...process.env, NO_UPDATE_NOTIFIER: "1" },
+	});
+	assert.equal(
+		result.status,
+		0,
+		`npm ${args.join(" ")} failed\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
+	);
+	return result;
+}
+
+test("a clean publish artifact installs and imports in an offline consumer", { timeout: 120_000 }, async () => {
+	const temporaryRoot = await mkdtemp(join(tmpdir(), "pi-agents-team-publish-"));
+	const cleanSource = join(temporaryRoot, "source");
+	const artifacts = join(temporaryRoot, "artifacts");
+	const consumer = join(temporaryRoot, "consumer");
+
+	try {
+		await Promise.all([mkdir(cleanSource), mkdir(artifacts), mkdir(consumer)]);
+
+		for (const file of ["package.json", "README.md", "LICENSE", "tsconfig.json", "tsconfig.publish.json"]) {
+			await cp(join(projectRoot, file), join(cleanSource, file));
+		}
+		for (const directory of ["extensions", "src", "prompts", "profiles", "scripts"]) {
+			await cp(join(projectRoot, directory), join(cleanSource, directory), { recursive: true });
+		}
+		await symlink(join(projectRoot, "node_modules"), join(cleanSource, "node_modules"), "junction");
+		assert.equal(existsSync(join(cleanSource, "dist")), false, "publish build must start without dist");
+
+		runNpm(["pack", "--pack-destination", artifacts, "--ignore-scripts=false"], cleanSource);
+		const tarballs = (await readdir(artifacts)).filter((entry) => entry.endsWith(".tgz"));
+		assert.equal(tarballs.length, 1, "npm pack should create exactly one tarball");
+
+		await writeFile(
+			join(consumer, "package.json"),
+			JSON.stringify({ name: "publish-contract-consumer", private: true, type: "module" }),
+		);
+		const tarball = join(artifacts, tarballs[0]!);
+		runNpm(
+			["install", "--offline", "--ignore-scripts", "--no-package-lock", "--no-save", tarball],
+			consumer,
+		);
+
+		const installedPackage = join(consumer, "node_modules", "pi-agents-team");
+		assert.equal(existsSync(join(installedPackage, "dist", "extensions", "index.js")), true);
+		assert.equal(existsSync(join(installedPackage, "src")), false, "source must not leak into the package");
+		const installedManifest = JSON.parse(await readFile(join(installedPackage, "package.json"), "utf8")) as {
+			version?: string;
+		};
+		const sourceManifest = JSON.parse(await readFile(join(projectRoot, "package.json"), "utf8")) as {
+			version?: string;
+		};
+		assert.equal(installedManifest.version, sourceManifest.version);
+
+		const imported = spawnSync(
+			process.execPath,
+			["--input-type=module", "--eval", 'import extension from "pi-agents-team"; if (typeof extension !== "function") process.exit(1)'],
+			{ cwd: consumer, encoding: "utf8" },
+		);
+		assert.equal(
+			imported.status,
+			0,
+			`consumer import failed for ${basename(tarball)}\nstdout:\n${imported.stdout}\nstderr:\n${imported.stderr}`,
+		);
+	} finally {
+		await rm(temporaryRoot, { recursive: true, force: true });
+	}
+});

--- a/tests/runtime/pi-version.test.ts
+++ b/tests/runtime/pi-version.test.ts
@@ -1,14 +1,18 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { EventEmitter } from "node:events";
+import { mkdtemp, mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { delimiter, join } from "node:path";
 import {
 	HOST_PI_VERSION,
+	SUCCESSFUL_PROBE_CACHE_TTL_MS,
+	buildPiVersionProbeCacheKey,
 	clearPiVersionProbeCache,
 	comparePiVersions,
 	parsePiVersion,
 	probeWorkerPiVersion,
+	terminateWindowsProcessTree,
 	type RunPiVersionCommand,
 } from "../../src/runtime/pi-version";
 
@@ -85,6 +89,84 @@ test("caches probes and coalesces concurrent first probes by command", async () 
 	assert.strictEqual(await first, await second);
 	await probeWorkerPiVersion(options, run);
 	assert.equal(calls, 1);
+});
+
+test("expires successful cache entries while continuing to coalesce pending probes", async (t) => {
+	let now = 1_000;
+	t.mock.method(Date, "now", () => now);
+	let calls = 0;
+	const run: RunPiVersionCommand = async () => {
+		calls += 1;
+		return { stdout: calls === 1 ? "0.80.6" : "0.81.0", stderr: "", code: 0 };
+	};
+	const options = { command: "ttl-pi", cwd: "/tmp" };
+	assert.equal((await probeWorkerPiVersion(options, run)).workerVersion, "0.80.6");
+	now += SUCCESSFUL_PROBE_CACHE_TTL_MS - 1;
+	assert.equal((await probeWorkerPiVersion(options, run)).workerVersion, "0.80.6");
+	now += 1;
+	assert.equal((await probeWorkerPiVersion(options, run)).workerVersion, "0.81.0");
+	assert.equal(calls, 2);
+});
+
+test("does not retain raw environment or CLI credential values in cache keys", () => {
+	const secret = "credential-value-that-must-not-be-retained";
+	const first = buildPiVersionProbeCacheKey("missing-pi", ["--token", secret, "--version"], "/tmp", {
+		PATH: "/credential/path",
+		API_TOKEN: secret,
+	});
+	const second = buildPiVersionProbeCacheKey("missing-pi", ["--token", secret, "--version"], "/tmp", {
+		PATH: "/credential/path",
+		API_TOKEN: `${secret}-changed`,
+	});
+	assert.doesNotMatch(first, /credential-value|API_TOKEN|credential\/path/);
+	assert.notEqual(first, second);
+});
+
+test("invalidates a successful probe when the resolved executable is replaced", async () => {
+	const root = await mkdtemp(join(tmpdir(), "pi-version-replace-"));
+	const executable = join(root, "pi");
+	const replacement = join(root, "pi-new");
+	await writeFile(executable, "first");
+	let calls = 0;
+	const run: RunPiVersionCommand = async () => {
+		calls += 1;
+		return { stdout: calls === 1 ? "0.80.6" : "0.81.0", stderr: "", code: 0 };
+	};
+	try {
+		assert.equal((await probeWorkerPiVersion({ command: executable, cwd: root }, run)).workerVersion, "0.80.6");
+		await writeFile(replacement, "second executable");
+		await rename(replacement, executable);
+		assert.equal((await probeWorkerPiVersion({ command: executable, cwd: root }, run)).workerVersion, "0.81.0");
+		assert.equal(calls, 2);
+	} finally {
+		await rm(root, { recursive: true, force: true });
+	}
+});
+
+test("Windows taskkill cleanup falls back on failure and kills a hung taskkill", async () => {
+	class FakeChild extends EventEmitter {
+		pid = 123;
+		killCalls = 0;
+		kill(): boolean {
+			this.killCalls += 1;
+			return true;
+		}
+	}
+
+	const failedChild = new FakeChild();
+	const failedKiller = new FakeChild();
+	await terminateWindowsProcessTree(failedChild, () => {
+		queueMicrotask(() => failedKiller.emit("close", 1));
+		return failedKiller;
+	}, 50);
+	assert.equal(failedChild.killCalls, 1);
+	assert.equal(failedKiller.killCalls, 0);
+
+	const hungChild = new FakeChild();
+	const hungKiller = new FakeChild();
+	await terminateWindowsProcessTree(hungChild, () => hungKiller, 10);
+	assert.equal(hungKiller.killCalls, 1);
+	assert.equal(hungChild.killCalls, 1);
 });
 
 test("preserves arbitrary value-taking wrapper options through the explicit Pi RPC boundary", async () => {

--- a/tests/runtime/pi-version.test.ts
+++ b/tests/runtime/pi-version.test.ts
@@ -122,6 +122,21 @@ test("does not retain raw environment or CLI credential values in cache keys", (
 	assert.notEqual(first, second);
 });
 
+test("does not expose a sensitive resolved PATH directory in cache keys", async () => {
+	const secret = "sensitive-resolved-directory-name";
+	const root = await mkdtemp(join(tmpdir(), `${secret}-`));
+	const executable = join(root, "pi");
+	await writeFile(executable, "resolved");
+	try {
+		const key = buildPiVersionProbeCacheKey("pi", ["--version"], root, { PATH: root });
+		assert.match(key, /^pi-version-probe:v1:[0-9a-f]{64}$/);
+		assert.doesNotMatch(key, new RegExp(secret));
+		assert.doesNotMatch(key, new RegExp(root.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+	} finally {
+		await rm(root, { recursive: true, force: true });
+	}
+});
+
 test("invalidates a successful probe when the resolved executable is replaced", async () => {
 	const root = await mkdtemp(join(tmpdir(), "pi-version-replace-"));
 	const executable = join(root, "pi");

--- a/tests/runtime/worker-manager.test.ts
+++ b/tests/runtime/worker-manager.test.ts
@@ -354,12 +354,12 @@ test("late extension diagnostics preserve authoritative worker error, abort, and
 	const exitManager = await launchRuntimeTestWorker("worker-extension-after-exit", exitTransport);
 	await exitManager.promptWorker("worker-extension-after-exit", "exit before extension diagnostic");
 	await waitForMicrotasks();
-	exitTransport.emit("exit", 7, null);
+	exitTransport.emit("exit", 0, null);
 	await waitForMicrotasks();
 	const exitBefore = exitManager.getWorker("worker-extension-after-exit")?.state;
 	assert.ok(exitBefore);
-	assert.equal(exitBefore.status, "error");
-	assert.match(exitBefore.error ?? "", /code 7/);
+	assert.equal(exitBefore.status, "exited");
+	assert.equal(exitBefore.error, undefined);
 	const runtime = exitManager as unknown as {
 		workers: Map<string, unknown>;
 		applyNormalizedEvent(record: unknown, event: { type: "worker_extension_error"; error: string; timestamp: number }): void;


### PR DESCRIPTION
## Description

Harden the install and version-probe contracts added earlier in the stack. This layer verifies the packed artifact offline, keeps published Pi dependency expectations aligned with the lockfile, and makes version-probe caching bounded, private, and sensitive to the resolved executable identity.

## Type of Change

- [ ] New feature
- [ ] Bug fix
- [x] Refactoring (no functional changes)
- [x] Documentation update
- [x] Infrastructure / CI/CD
- [ ] Performance improvement

## Changes Made

- Add an offline package test that builds, packs, installs, imports, and loads the compiled extension without registry access.
- Verify published dependency versions and package-lock consistency.
- Bound successful Pi probe cache entries and refresh them after the configured TTL.
- Key probes by resolved executable and wrapper-prefix identity so PATH or binary replacement cannot reuse a stale result.
- Hash sensitive cache-key inputs and keep raw paths, environment values, and wrapper arguments out of diagnostic cache helpers.
- Make package import subprocess failures report actionable stdout/stderr context.
- Document package activation, build validation, Pi preflight, supported mismatches, and recovery expectations.

## How to Test

1. Run `npm ci`.
2. Run `npm run check`.
3. Inspect `tests/package-publish.test.ts` for the offline pack/install/import/load contract.

Verified on this branch:

- `npm run check`: 507 passed, 0 failed.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-reviewed the code for obvious errors
- [x] Added or updated tests where applicable
- [x] Existing tests pass locally
- [x] Updated documentation if needed
- [x] No new warnings or console errors introduced

## Related Issues

None found in the branch name or commit history.

## Screenshots

Not applicable. This is package, probe, test, and documentation hardening.

## Stack

4 of 5. Base: `feat/compact-worker-persistence`. Review after PR 3. The final PR is `fix/cancellable-worker-lifecycle`.
