### PR TITLE
Make worker cancellation and cleanup bounded

### DIFF
--- a/.ignore
+++ b/.ignore
@@ -1,2 +1,0 @@
-!.slim/deepwork/
-!.slim/deepwork/**

--- a/extensions/pi-agent-team/index.ts
+++ b/extensions/pi-agent-team/index.ts
@@ -6,9 +6,7 @@ import {
 	CompactPersistenceJournal,
 	compactPersistenceRecordPayloadBytes,
 	markRestoredWorkersExited,
-	isRecognizedCompactPersistenceRecord,
-	measureCompactPersistence,
-	restorePersistedTeamState,
+	restorePersistedTeamStateWithMeasurement,
 	type CompactPersistenceMeasurement,
 } from "../../src/control-plane/persistence.js";
 import { buildOrchestratorPromptBundle } from "../../src/prompts/contracts.js";
@@ -28,7 +26,7 @@ import { formatAgentMessageResult, formatAgentResultNotReady, formatDelegateTask
 import { renderAgentToolCallTitle } from "../../src/ui/tool-renderers.js";
 import type { NormalizedWorkerEvent } from "../../src/runtime/event-normalizer.js";
 import type { WorkerPiVersionMismatchEvent } from "../../src/runtime/worker-manager.js";
-import { THINKING_LEVELS, type LoadedTeamProjectConfig, type PersistedTeamState, type TeamConfig, type ThinkingLevel, type ThinkingLevelConfigWarning, type WorkerRuntimeState } from "../../src/types.js";
+import { THINKING_LEVELS, type LoadedTeamProjectConfig, type PersistedTeamState, type TeamConfig, type TeamPersistenceRecord, type ThinkingLevel, type ThinkingLevelConfigWarning, type WorkerRuntimeState } from "../../src/types.js";
 
 const DelegateTaskSchema = Type.Object({
 	title: Type.String({ description: "Short title for the delegated task" }),
@@ -193,45 +191,6 @@ interface PersistenceSessionEntry {
 	data?: unknown;
 }
 
-function activeBranchWithPersistenceTail(
-	sessionManager: {
-		getBranch?: () => Iterable<PersistenceSessionEntry>;
-		getEntries: () => Iterable<PersistenceSessionEntry>;
-		getLeafId?: () => string | null;
-	},
-	stateCustomType: string,
-): PersistenceSessionEntry[] {
-	const branch = Array.from(sessionManager.getBranch?.() ?? sessionManager.getEntries());
-	const leafId = sessionManager.getLeafId?.();
-	if (leafId === undefined) return branch;
-
-	const childrenByParent = new Map<string | null, PersistenceSessionEntry[]>();
-	for (const entry of sessionManager.getEntries()) {
-		const entryParentId = entry.parentId;
-		if ((typeof entryParentId !== "string" && entryParentId !== null)
-			|| entry.type !== "custom"
-			|| entry.customType !== stateCustomType
-			|| !isRecognizedCompactPersistenceRecord(entry.data)
-			|| typeof entry.id !== "string") continue;
-		const children = childrenByParent.get(entryParentId) ?? [];
-		children.push(entry);
-		childrenByParent.set(entryParentId, children);
-	}
-
-	const visited = new Set(branch.flatMap((entry) => typeof entry.id === "string" ? [entry.id] : []));
-	let parentId: string | null = leafId;
-	while (true) {
-		const candidates = (childrenByParent.get(parentId) ?? []).filter((entry) => !visited.has(entry.id!));
-		// Multiple valid children are distinct branches. There is no ordering signal
-		// that makes one of those siblings the active persistence tail.
-		if (candidates.length !== 1) break;
-		const next = candidates[0]!;
-		branch.push(next);
-		visited.add(next.id!);
-		parentId = next.id!;
-	}
-	return branch;
-}
 
 interface SessionFileBoundary {
 	path: string;
@@ -310,14 +269,11 @@ function restoreLatestState(
 ): { state: PersistedTeamState; markedCount: number; persistenceMeasurement: CompactPersistenceMeasurement } {
 	const sessionManager = ctx.sessionManager as typeof ctx.sessionManager & {
 		getBranch?: () => Iterable<PersistenceSessionEntry>;
-		getEntries: () => Iterable<PersistenceSessionEntry>;
-		getLeafId?: () => string | null;
 	};
-	const branch = activeBranchWithPersistenceTail(sessionManager, config.persistence.stateCustomType);
-	const restoredState = restorePersistedTeamState(branch, config.persistence.stateCustomType);
-	const persistenceMeasurement = measureCompactPersistence(branch, config.persistence.stateCustomType);
-	const { state, markedCount } = markRestoredWorkersExited(restoredState, startReason);
-	return { state, markedCount, persistenceMeasurement };
+	const branch = sessionManager.getBranch?.() ?? [];
+	const restored = restorePersistedTeamStateWithMeasurement(branch, config.persistence.stateCustomType);
+	const { state, markedCount } = markRestoredWorkersExited(restored.state, startReason);
+	return { state, markedCount, persistenceMeasurement: restored.measurement };
 }
 
 function applyUi(
@@ -493,7 +449,6 @@ function createPiVersionMismatchNotifier(notify: (message: string) => void): {
 }
 
 export const _testing = {
-	activeBranchWithPersistenceTail,
 	createPersistenceGrowthMonitor,
 	PERSISTENCE_BYTE_WARNING_THRESHOLD,
 	PERSISTENCE_GROWTH_WARNING,
@@ -802,7 +757,7 @@ export default function (pi: ExtensionAPI): void {
 		if (leafId !== undefined) navigation.appendLeafId = leafId;
 	}
 
-	function appendPreparedPersistence(maxBatches = 2): boolean {
+	function appendPreparedPersistence(maxBatches = 2, initialRecords?: readonly TeamPersistenceRecord[]): boolean {
 		const sessionManagerAtStart = currentSessionManager();
 		if (sessionManagerAtStart && persistenceIntegrityBlockedManagers.has(sessionManagerAtStart)) {
 			warnPersistenceFailure(PERSISTENCE_AMBIGUOUS_BLOCKED_WARNING);
@@ -810,7 +765,9 @@ export default function (pi: ExtensionAPI): void {
 		}
 
 		for (let batch = 0; batch < maxBatches; batch += 1) {
-			const records = persistenceJournal.prepare(teamState, activeProjectConfig.config);
+			const records = batch === 0 && initialRecords
+				? initialRecords
+				: persistenceJournal.prepare(teamState, activeProjectConfig.config);
 			if (records.length === 0) return true;
 			for (const record of records) {
 				const leafBeforeAppend = currentLeafId();
@@ -916,6 +873,14 @@ export default function (pi: ExtensionAPI): void {
 	function attachTeamManagerListener(manager: TeamManager): void {
 		detachTeamManagerListener();
 		resetUiTracking();
+		const detachBeforePromptListener = manager.onBeforePrompt((state) => {
+			teamState = state;
+			const checkpointRecords = persistenceJournal.prepareDetachedWorkers(teamState, activeProjectConfig.config);
+			if (!appendPreparedPersistence(1, checkpointRecords)) {
+				warnPersistenceFailure(PERSISTENCE_LIVE_WARNING);
+				throw new Error("Worker prompt was not sent because its durable persistence checkpoint could not be appended.");
+			}
+		});
 		const detachStateListener = manager.onStateChange((state) => {
 			teamState = state;
 			// Persistence is best-effort at this callback boundary. Pi invokes state
@@ -985,6 +950,7 @@ export default function (pi: ExtensionAPI): void {
 			// old pending data before replacement, and this old listener must not
 			// derive or append another old-branch candidate at the new leaf.
 			if (flushPersistence && !provisionalTreeNavigation?.confirmed) flushPendingPersistence();
+			detachBeforePromptListener();
 			detachStateListener();
 			detachWorkerEventListener();
 			detachVersionMismatchListener();
@@ -1033,7 +999,7 @@ export default function (pi: ExtensionAPI): void {
 		description: "Launch a background Pi RPC worker for a bounded delegated task and track it in the orchestrator state.",
 		parameters: DelegateTaskSchema,
 		renderCall: renderAgentToolCallTitle("delegate_task"),
-		async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
+		async execute(_toolCallId, params, signal, _onUpdate, ctx) {
 			ensureNotReloading();
 			if (!activeProjectConfig.enabled) {
 				throw new Error(getDisabledMessage(activeProjectConfig));
@@ -1069,7 +1035,7 @@ export default function (pi: ExtensionAPI): void {
 				projectTrusted,
 				projectTrustRoot: projectTrusted === undefined ? undefined : activeProjectConfig.projectRoot ?? ctx.cwd,
 				reuseWorkerId: params.reuseWorkerId,
-			});
+			}, signal);
 			teamState = teamManager.snapshot();
 			renderUi(activeContext, teamState, spinnerFrame, activeProjectConfig.config, isTeamActive(activeProjectConfig), teamManager.routingMode, activeProjectConfig.displayCost);
 			return {

--- a/src/control-plane/persistence.ts
+++ b/src/control-plane/persistence.ts
@@ -2,10 +2,12 @@ import { createHash } from "node:crypto";
 import { createDefaultTeamState, DEFAULT_TEAM_CONFIG, normalizePersistedTeamState } from "../config.js";
 import { addWorkerUsageToAggregate } from "../usage.js";
 import {
+	PERSISTED_TERMINAL_WORKER_STATUSES,
 	TEAM_PERSISTENCE_VERSION,
-	WORKER_STATUSES,
 	type CompactPersistedWorker,
+	type CompactPersistedWorkerSummary,
 	type PersistedTeamState,
+	type PersistedTerminalWorkerStatus,
 	type TeamConfig,
 	type TeamPersistenceRecord,
 	type WorkerRuntimeState,
@@ -37,13 +39,6 @@ export interface RestorePersistedTeamStateWithMeasurementResult {
 }
 
 const LIVE_WORKER_STATUSES: readonly WorkerStatus[] = ["running", "starting", "idle", "waiting_followup"];
-const TERMINAL_WORKER_STATUS: Partial<Record<WorkerStatus, true>> = {
-	idle: true,
-	completed: true,
-	aborted: true,
-	error: true,
-	exited: true,
-};
 const MAX_ID_BYTES = 256;
 const MAX_RECORD_ID_BYTES = 256;
 const MAX_SUMMARY_TEXT_BYTES = 512;
@@ -59,8 +54,9 @@ const REASON_MESSAGE: Record<SessionStartReason, string> = {
 	new: "Pi Agents Team new session started; prior workers are no longer attached.",
 };
 
-function isPersistableTerminalStatus(status: unknown): status is WorkerStatus {
-	return typeof status === "string" && TERMINAL_WORKER_STATUS[status as WorkerStatus] === true;
+function isPersistableTerminalStatus(status: unknown): status is PersistedTerminalWorkerStatus {
+	return typeof status === "string"
+		&& (PERSISTED_TERMINAL_WORKER_STATUSES as readonly string[]).includes(status);
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -111,7 +107,12 @@ function compactStrings(value: unknown, maxItems: number): string[] {
 	return value.slice(0, Math.min(configuredLimit, MAX_SUMMARY_ITEMS)).map((item) => cap(item));
 }
 
-function compactWorker(worker: WorkerRuntimeState, config: TeamConfig): CompactPersistedWorker {
+type CompactWorkerSnapshot = Omit<CompactPersistedWorker, "status" | "lastSummary"> & {
+	status: WorkerStatus;
+	lastSummary?: Omit<CompactPersistedWorkerSummary, "status"> & { status: WorkerStatus };
+};
+
+function compactWorker(worker: WorkerRuntimeState, config: TeamConfig): CompactWorkerSnapshot {
 	const summary = worker.lastSummary;
 	return {
 		workerId: cap(worker.workerId, MAX_ID_BYTES),
@@ -130,6 +131,22 @@ function compactWorker(worker: WorkerRuntimeState, config: TeamConfig): CompactP
 		} : undefined,
 		usage: compactUsage(worker.usage),
 	};
+}
+
+function persistedTerminalWorker(worker: CompactWorkerSnapshot): CompactPersistedWorker {
+	const withStatus = <Status extends PersistedTerminalWorkerStatus>(status: Status) => ({
+		...worker,
+		status,
+		lastSummary: worker.lastSummary ? { ...worker.lastSummary, status } : undefined,
+	});
+	switch (worker.status) {
+		case "idle": return withStatus("idle");
+		case "completed": return withStatus("completed");
+		case "aborted": return withStatus("aborted");
+		case "error": return withStatus("error");
+		case "exited": return withStatus("exited");
+		default: throw new Error("Compact persistence writer requires a terminal worker status.");
+	}
 }
 
 function isPlainRecord(value: unknown): value is Record<string, unknown> {
@@ -220,7 +237,7 @@ function sanitizeCompactWorker(value: unknown): CompactPersistedWorker | undefin
 			&& !isBoundedString(value.lastSummary.nextRecommendation, MAX_SUMMARY_TEXT_BYTES)) return undefined;
 		lastSummary = {
 			headline: value.lastSummary.headline,
-			status: value.status as WorkerStatus,
+			status: value.status,
 			readFiles,
 			changedFiles,
 			risks,
@@ -228,18 +245,18 @@ function sanitizeCompactWorker(value: unknown): CompactPersistedWorker | undefin
 			updatedAt: value.lastSummary.updatedAt,
 		};
 	}
-	return {
+	return persistedTerminalWorker({
 		workerId: value.workerId,
 		profileName: value.profileName,
-		status: value.status as WorkerStatus,
+		status: value.status,
 		startedAt: value.startedAt,
 		lastEventAt: value.lastEventAt,
 		lastSummary,
 		usage,
-	};
+	});
 }
 
-function restoredWorker(worker: CompactPersistedWorker): WorkerRuntimeState {
+function restoredWorker(worker: CompactWorkerSnapshot): WorkerRuntimeState {
 	return {
 		workerId: worker.workerId,
 		profileName: worker.profileName,
@@ -519,7 +536,7 @@ function sameUsage(left: WorkerUsageStats, right: WorkerUsageStats): boolean {
 		&& left.contextRemainingTokens === right.contextRemainingTokens;
 }
 
-function durableEqual(left: CompactPersistedWorker, right: CompactPersistedWorker): boolean {
+function durableEqual(left: CompactWorkerSnapshot, right: CompactWorkerSnapshot): boolean {
 	if (left.workerId !== right.workerId
 		|| left.profileName !== right.profileName
 		|| left.status !== right.status
@@ -546,9 +563,9 @@ type PendingTransition =
 
 /** Compact v2 transition journal with append-before-commit semantics. */
 export class CompactPersistenceJournal {
-	private previousWorkers = new Map<string, CompactPersistedWorker>();
-	private observedWorkers = new Map<string, CompactPersistedWorker>();
-	private observedSources = new Map<string, CompactPersistedWorker>();
+	private previousWorkers = new Map<string, CompactWorkerSnapshot>();
+	private observedWorkers = new Map<string, CompactWorkerSnapshot>();
+	private observedSources = new Map<string, CompactWorkerSnapshot>();
 	private observedRecords = new Map<string, Extract<TeamPersistenceRecord, { kind: "worker_terminal" }>>();
 	private pending = new Map<string, PendingTransition>();
 
@@ -564,7 +581,7 @@ export class CompactPersistenceJournal {
 			const compact = compactWorker(worker, config);
 			this.observedSources.set(worker.workerId, compact);
 			if (isPersistableTerminalStatus(worker.status)) {
-				const record = terminalRecord(compact, this.instrumentation);
+				const record = terminalRecord(persistedTerminalWorker(compact), this.instrumentation);
 				this.previousWorkers.set(worker.workerId, record.worker);
 				this.observedWorkers.set(worker.workerId, record.worker);
 				this.observedRecords.set(worker.workerId, record);
@@ -583,7 +600,7 @@ export class CompactPersistenceJournal {
 				&& isPersistableTerminalStatus(priorSource.status)
 				&& LIVE_WORKER_STATUSES.includes(worker.status)
 				&& !isPersistableTerminalStatus(worker.status)) {
-				const checkpointWorker = compactWorker({ ...worker, status: "exited" }, config);
+				const checkpointWorker = persistedTerminalWorker(compactWorker({ ...worker, status: "exited" }, config));
 				const checkpointRecord = terminalRecord(checkpointWorker, this.instrumentation);
 				for (const [pendingId, transition] of this.pending) {
 					if ("worker" in transition && transition.worker.workerId === worker.workerId) {
@@ -607,7 +624,7 @@ export class CompactPersistenceJournal {
 				&& durableEqual(priorSource, compact)
 				&& this.observedWorkers.has(worker.workerId)
 				&& this.observedRecords.has(worker.workerId)) continue;
-			const record = terminalRecord(compact, this.instrumentation);
+			const record = terminalRecord(persistedTerminalWorker(compact), this.instrumentation);
 			this.observedWorkers.set(worker.workerId, record.worker);
 			this.observedRecords.set(worker.workerId, record);
 		}
@@ -668,7 +685,9 @@ export class CompactPersistenceJournal {
 			if (!isPersistableTerminalStatus(worker.status)) {
 				// Runtime-only churn needs no append, but remains the source for a
 				// later terminal/prune transition.
-				this.previousWorkers.set(worker.workerId, observed);
+				if (!previous || !isPersistableTerminalStatus(previous.status)) {
+					this.previousWorkers.set(worker.workerId, observed);
+				}
 				continue;
 			}
 			const record = this.observedRecords.get(worker.workerId);
@@ -688,7 +707,7 @@ export class CompactPersistenceJournal {
 		this.observeCurrentWorkers(state, config);
 		for (const worker of Object.values(state.activeWorkers)) {
 			if (!LIVE_WORKER_STATUSES.includes(worker.status)) continue;
-			const detached = compactWorker({ ...worker, status: "exited" }, config);
+			const detached = persistedTerminalWorker(compactWorker({ ...worker, status: "exited" }, config));
 			const record = terminalRecord(detached, this.instrumentation);
 			const previous = this.previousWorkers.get(worker.workerId);
 			if (previous && isPersistableTerminalStatus(previous.status) && durableEqual(previous, record.worker)) continue;
@@ -702,9 +721,11 @@ export class CompactPersistenceJournal {
 		if (!transition) return;
 		if ("worker" in transition) {
 			this.previousWorkers.set(transition.worker.workerId, transition.worker);
-			if (!transition.detached) {
-				this.observedWorkers.set(transition.worker.workerId, transition.worker);
-			}
+			// A committed detached checkpoint is the durable observation baseline too.
+			// observedSources still tracks the unchanged live runtime, so later real
+			// revisions can supersede this exited snapshot without re-emitting it.
+			this.observedWorkers.set(transition.worker.workerId, transition.worker);
+			this.observedRecords.set(transition.worker.workerId, transition.record);
 		} else {
 			this.previousWorkers.delete(transition.workerId);
 			this.observedWorkers.delete(transition.workerId);

--- a/src/control-plane/persistence.ts
+++ b/src/control-plane/persistence.ts
@@ -31,6 +31,11 @@ export interface CompactPersistenceMeasurement {
 	payloadBytes: number;
 }
 
+export interface RestorePersistedTeamStateWithMeasurementResult {
+	state: PersistedTeamState;
+	measurement: CompactPersistenceMeasurement;
+}
+
 const LIVE_WORKER_STATUSES: readonly WorkerStatus[] = ["running", "starting", "idle", "waiting_followup"];
 const TERMINAL_WORKER_STATUS: Partial<Record<WorkerStatus, true>> = {
 	idle: true,
@@ -78,7 +83,10 @@ function compactUsage(usage: Partial<WorkerUsageStats> | undefined): WorkerUsage
 		costUsd: finite(usage?.costUsd),
 	};
 	for (const key of ["contextTokens", "contextWindow", "contextPercent", "contextRemainingTokens"] as const) {
-		if (typeof usage?.[key] === "number" && Number.isFinite(usage[key])) result[key] = usage[key];
+		const value = usage?.[key];
+		if (typeof value === "number" && Number.isFinite(value) && value >= 0) {
+			result[key] = Math.min(value, MAX_PERSISTED_NUMBER);
+		}
 	}
 	return result;
 }
@@ -257,20 +265,54 @@ function isLegacySnapshot(value: unknown): boolean {
 	return isRecord(value) && value.version === 1 && isRecord(value.activeWorkers);
 }
 
+interface InspectedCompactPersistenceRecord {
+	record: TeamPersistenceRecord;
+	payloadBytes: number;
+}
+
+/**
+ * Validate and canonicalize a compact record in one pass. The canonical copy
+ * is the only value serialized and is reused by replay.
+ */
+function inspectCompactPersistenceRecord(value: unknown): InspectedCompactPersistenceRecord | undefined {
+	if (!isPlainRecord(value) || value.version !== TEAM_PERSISTENCE_VERSION) return undefined;
+	if (!isBoundedString(value.recordId, MAX_RECORD_ID_BYTES, false)) return undefined;
+
+	let record: TeamPersistenceRecord;
+	if (value.kind === "worker_terminal") {
+		if (!hasExactKeys(value, ["version", "kind", "recordId", "worker"])) return undefined;
+		const worker = sanitizeCompactWorker(value.worker);
+		if (!worker) return undefined;
+		record = {
+			version: TEAM_PERSISTENCE_VERSION,
+			kind: "worker_terminal",
+			recordId: value.recordId,
+			worker,
+		};
+	} else if (value.kind === "worker_pruned") {
+		if (!hasExactKeys(value, ["version", "kind", "recordId", "workerId", "usage"])) return undefined;
+		if (!isBoundedString(value.workerId, MAX_ID_BYTES, false)) return undefined;
+		const usage = sanitizeUsage(value.usage);
+		if (!usage) return undefined;
+		record = {
+			version: TEAM_PERSISTENCE_VERSION,
+			kind: "worker_pruned",
+			recordId: value.recordId,
+			workerId: value.workerId,
+			usage,
+		};
+	} else {
+		return undefined;
+	}
+
+	const payloadBytes = Buffer.byteLength(JSON.stringify(record), "utf8");
+	if (payloadBytes > MAX_RECORD_BYTES) return undefined;
+	return { record, payloadBytes };
+}
+
 /** True only for replayable records in the current compact format. */
 export function isRecognizedCompactPersistenceRecord(value: unknown): value is TeamPersistenceRecord {
-	if (!isPlainRecord(value) || value.version !== TEAM_PERSISTENCE_VERSION) return false;
-	if (!isBoundedString(value.recordId, MAX_RECORD_ID_BYTES, false)) return false;
-	if (value.kind === "worker_terminal") {
-		if (!hasExactKeys(value, ["version", "kind", "recordId", "worker"])) return false;
-		if (!sanitizeCompactWorker(value.worker)) return false;
-	} else if (value.kind === "worker_pruned") {
-		if (!hasExactKeys(value, ["version", "kind", "recordId", "workerId", "usage"])) return false;
-		if (!isBoundedString(value.workerId, MAX_ID_BYTES, false) || !sanitizeUsage(value.usage)) return false;
-	} else {
-		return false;
-	}
-	return Buffer.byteLength(JSON.stringify(value), "utf8") <= MAX_RECORD_BYTES;
+	return inspectCompactPersistenceRecord(value) !== undefined;
 }
 
 /** UTF-8 bytes occupied by the compact record payload, not session framing or total file bytes. */
@@ -286,9 +328,10 @@ export function measureCompactPersistence(
 	let payloadBytes = 0;
 	for (const entry of entries) {
 		if (entry.type !== "custom" || entry.customType !== stateCustomType) continue;
-		if (!isRecognizedCompactPersistenceRecord(entry.data)) continue;
+		const inspected = inspectCompactPersistenceRecord(entry.data);
+		if (!inspected) continue;
 		recordCount += 1;
-		payloadBytes += compactPersistenceRecordPayloadBytes(entry.data);
+		payloadBytes += inspected.payloadBytes;
 	}
 	return { recordCount, payloadBytes };
 }
@@ -313,9 +356,13 @@ function sanitizeLegacyState(raw: unknown): PersistedTeamState {
 	return normalizePersistedTeamState(state);
 }
 
-export function restorePersistedTeamState(entries: Iterable<SessionLikeEntry>, stateCustomType: string): PersistedTeamState {
+export function restorePersistedTeamStateWithMeasurement(
+	entries: Iterable<SessionLikeEntry>,
+	stateCustomType: string,
+): RestorePersistedTeamStateWithMeasurementResult {
 	let state = createDefaultTeamState();
 	const appliedRecords = new Set<string>();
+	const measurement: CompactPersistenceMeasurement = { recordCount: 0, payloadBytes: 0 };
 
 	for (const entry of entries) {
 		if (entry.type !== "custom" || entry.customType !== stateCustomType) continue;
@@ -327,23 +374,29 @@ export function restorePersistedTeamState(entries: Iterable<SessionLikeEntry>, s
 		}
 		// Unknown, malformed, and future-version records are inert. In particular,
 		// they must not erase the valid replay prefix as an alleged legacy snapshot.
-		if (!isRecognizedCompactPersistenceRecord(value)) continue;
-		if (appliedRecords.has(value.recordId)) continue;
+		const inspected = inspectCompactPersistenceRecord(value);
+		if (!inspected) continue;
+		measurement.recordCount += 1;
+		measurement.payloadBytes += inspected.payloadBytes;
 
-		if (value.kind === "worker_terminal") {
-			const worker = sanitizeCompactWorker(value.worker);
-			if (!worker) continue;
-			appliedRecords.add(value.recordId);
-			state.activeWorkers[worker.workerId] = restoredWorker(worker);
+		const record = inspected.record;
+		if (appliedRecords.has(record.recordId)) continue;
+		appliedRecords.add(record.recordId);
+		if (record.kind === "worker_terminal") {
+			state.activeWorkers[record.worker.workerId] = restoredWorker(record.worker);
 		} else {
-			if (typeof value.workerId !== "string" || !isRecord(value.usage)) continue;
-			appliedRecords.add(value.recordId);
-			const workerId = cap(value.workerId, MAX_ID_BYTES);
-			delete state.activeWorkers[workerId];
-			state.prunedWorkerUsageTotals = addWorkerUsageToAggregate(state.prunedWorkerUsageTotals, compactUsage(value.usage));
+			delete state.activeWorkers[record.workerId];
+			state.prunedWorkerUsageTotals = addWorkerUsageToAggregate(
+				state.prunedWorkerUsageTotals,
+				record.usage,
+			);
 		}
 	}
-	return normalizePersistedTeamState(state);
+	return { state: normalizePersistedTeamState(state), measurement };
+}
+
+export function restorePersistedTeamState(entries: Iterable<SessionLikeEntry>, stateCustomType: string): PersistedTeamState {
+	return restorePersistedTeamStateWithMeasurement(entries, stateCustomType).state;
 }
 
 export function markRestoredWorkersExited(state: PersistedTeamState, reasonOrStartReason: string | SessionStartReason = "reload"): MarkRestoredWorkersExitedResult {
@@ -396,8 +449,17 @@ function terminalRecord(
 		recordId: recordId("terminal", worker, instrumentation),
 		worker,
 	});
+	const finish = (
+		candidate: Extract<TeamPersistenceRecord, { kind: "worker_terminal" }>,
+	): Extract<TeamPersistenceRecord, { kind: "worker_terminal" }> => {
+		const inspected = inspectCompactPersistenceRecord(candidate);
+		if (!inspected || inspected.record.kind !== "worker_terminal") {
+			throw new Error("Compact persistence terminal writer produced an unreadable record.");
+		}
+		return inspected.record;
+	};
 	let record = build();
-	if (recordBytes(record) <= MAX_RECORD_BYTES) return record;
+	if (recordBytes(record) <= MAX_RECORD_BYTES) return finish(record);
 
 	const summary = worker.lastSummary;
 	if (summary) {
@@ -422,22 +484,22 @@ function terminalRecord(
 			}
 			summary[field] = values.slice(0, retained);
 			record = build();
-			if (recordBytes(record) <= MAX_RECORD_BYTES) return record;
+			if (recordBytes(record) <= MAX_RECORD_BYTES) return finish(record);
 		}
 
 		summary.nextRecommendation = undefined;
 		record = build();
-		if (recordBytes(record) <= MAX_RECORD_BYTES) return record;
+		if (recordBytes(record) <= MAX_RECORD_BYTES) return finish(record);
 		summary.headline = "";
 		record = build();
-		if (recordBytes(record) <= MAX_RECORD_BYTES) return record;
+		if (recordBytes(record) <= MAX_RECORD_BYTES) return finish(record);
 		worker.lastSummary = undefined;
 		record = build();
 	}
 	if (recordBytes(record) > MAX_RECORD_BYTES) {
 		throw new Error("Compact persistence terminal record exceeds the enforced byte budget.");
 	}
-	return record;
+	return finish(record);
 }
 
 function sameStrings(left: readonly string[], right: readonly string[]): boolean {
@@ -517,6 +579,23 @@ export class CompactPersistenceJournal {
 		for (const worker of Object.values(state.activeWorkers)) {
 			const compact = compactWorker(worker, config);
 			const priorSource = this.observedSources.get(worker.workerId);
+			if (priorSource
+				&& isPersistableTerminalStatus(priorSource.status)
+				&& LIVE_WORKER_STATUSES.includes(worker.status)
+				&& !isPersistableTerminalStatus(worker.status)) {
+				const checkpointWorker = compactWorker({ ...worker, status: "exited" }, config);
+				const checkpointRecord = terminalRecord(checkpointWorker, this.instrumentation);
+				for (const [pendingId, transition] of this.pending) {
+					if ("worker" in transition && transition.worker.workerId === worker.workerId) {
+						this.pending.delete(pendingId);
+					}
+				}
+				this.pending.set(checkpointRecord.recordId, {
+					record: checkpointRecord,
+					worker: checkpointRecord.worker,
+					detached: true,
+				});
+			}
 			this.observedSources.set(worker.workerId, compact);
 			if (!isPersistableTerminalStatus(worker.status)) {
 				this.observedWorkers.set(worker.workerId, compact);
@@ -572,7 +651,14 @@ export class CompactPersistenceJournal {
 			if (recordBytes(record) > MAX_RECORD_BYTES) {
 				throw new Error("Compact persistence prune record exceeds the enforced byte budget.");
 			}
-			this.pending.set(record.recordId, { record, workerId });
+			const inspected = inspectCompactPersistenceRecord(record);
+			if (!inspected || inspected.record.kind !== "worker_pruned") {
+				throw new Error("Compact persistence prune writer produced an unreadable record.");
+			}
+			this.pending.set(inspected.record.recordId, {
+				record: inspected.record,
+				workerId,
+			});
 		}
 
 		for (const worker of Object.values(state.activeWorkers)) {

--- a/src/control-plane/team-manager.ts
+++ b/src/control-plane/team-manager.ts
@@ -221,6 +221,11 @@ export class TeamManager {
 		return () => this.events.off("state_change", listener);
 	}
 
+	onBeforePrompt(listener: (state: PersistedTeamState) => void): () => void {
+		this.events.on("before_prompt", listener);
+		return () => this.events.off("before_prompt", listener);
+	}
+
 	restore(state: PersistedTeamState): void {
 		this.registry.restore(state);
 		for (const worker of this.registry.listWorkers()) {
@@ -238,7 +243,7 @@ export class TeamManager {
 		return this.registry.snapshot();
 	}
 
-	async delegateTask(request: DelegateTaskRequest): Promise<AgentResult> {
+	async delegateTask(request: DelegateTaskRequest, signal?: AbortSignal): Promise<AgentResult> {
 		const profile = this.config.profiles.find((item) => item.name === request.profileName);
 		if (!profile) {
 			const available = this.config.profiles.map((item) => item.name).join(", ") || "(none)";
@@ -248,7 +253,7 @@ export class TeamManager {
 		}
 
 		if (request.reuseWorkerId) {
-			return this.reuseWorkerForTask(request);
+			return this.reuseWorkerForTask(request, signal);
 		}
 		const launchPlan = applyLaunchPolicy(
 			{
@@ -308,6 +313,7 @@ export class TeamManager {
 				// the task prompt's requested-skill instructions are impossible to
 				// satisfy.
 				allowSkills: task.skills !== undefined && task.skills.length > 0,
+				signal,
 			});
 		} catch (error) {
 			this.registry.removeWorker(workerId);
@@ -317,6 +323,22 @@ export class TeamManager {
 		}
 
 		this.registry.upsertWorker(worker.state);
+		try {
+			signal?.throwIfAborted();
+			this.events.emit("before_prompt", this.snapshot());
+			signal?.throwIfAborted();
+		} catch (error) {
+			try {
+				await this.workerManager.shutdownWorker(workerId);
+			} catch {
+				// Preserve the checkpoint/cancellation error; process disposal is bounded.
+			}
+			await this.workerManager.removeWorker(workerId);
+			this.registry.removeWorker(workerId);
+			this.registry.unregisterTask(taskId);
+			this.events.emit("state_change", this.snapshot());
+			throw error;
+		}
 		await this.workerManager.promptWorker(workerId, buildWorkerTaskPrompt(task));
 		const liveWorker = this.workerManager.getWorker(workerId);
 		if (liveWorker) {
@@ -545,7 +567,7 @@ export class TeamManager {
 		};
 	}
 
-	private async reuseWorkerForTask(request: DelegateTaskRequest): Promise<AgentResult> {
+	private async reuseWorkerForTask(request: DelegateTaskRequest, signal?: AbortSignal): Promise<AgentResult> {
 		const requestedId = request.reuseWorkerId!;
 		const resolvedId = this.resolveWorkerId(requestedId) ?? requestedId;
 		const target = this.registry.getWorker(resolvedId);
@@ -611,7 +633,8 @@ export class TeamManager {
 			);
 		}
 
-		await this.workerManager.refreshStats(resolvedId);
+		signal?.throwIfAborted();
+		await this.workerManager.refreshStats(resolvedId, signal);
 		const refreshedWorker = this.workerManager.getWorker(resolvedId);
 		if (refreshedWorker) {
 			this.registry.upsertWorker(refreshedWorker.state);
@@ -637,7 +660,25 @@ export class TeamManager {
 		};
 
 		this.registry.registerTask(task);
-		await this.workerManager.reuseWorker(resolvedId, buildWorkerTaskPrompt(task), task);
+		const preparedWorker = this.workerManager.prepareWorkerReuse(resolvedId, task);
+		this.registry.upsertWorker(preparedWorker.state);
+		try {
+			signal?.throwIfAborted();
+			this.events.emit("before_prompt", this.snapshot());
+			signal?.throwIfAborted();
+		} catch (error) {
+			try {
+				await this.workerManager.shutdownWorker(resolvedId);
+			} catch {
+				// Preserve the checkpoint/cancellation error; process disposal is bounded.
+			}
+			const exited = this.registry.markWorkerExited(resolvedId, "Worker closed before reuse prompt.");
+			if (exited) this.registry.upsertWorker(exited);
+			this.registry.unregisterTask(taskId);
+			this.events.emit("state_change", this.snapshot());
+			throw error;
+		}
+		await this.workerManager.promptWorker(resolvedId, buildWorkerTaskPrompt(task));
 		const liveWorker = this.workerManager.getWorker(resolvedId);
 		if (liveWorker) {
 			this.registry.upsertWorker(liveWorker.state);

--- a/src/runtime/deferred.ts
+++ b/src/runtime/deferred.ts
@@ -1,0 +1,15 @@
+export interface Deferred<T> {
+	promise: Promise<T>;
+	resolve(value: T | PromiseLike<T>): void;
+	reject(reason?: unknown): void;
+}
+
+export function createDeferred<T>(): Deferred<T> {
+	let resolve!: Deferred<T>["resolve"];
+	let reject!: Deferred<T>["reject"];
+	const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+		resolve = resolvePromise;
+		reject = rejectPromise;
+	});
+	return { promise, resolve, reject };
+}

--- a/src/runtime/pi-version.ts
+++ b/src/runtime/pi-version.ts
@@ -2,7 +2,7 @@ import { spawn as nodeSpawn } from "node:child_process";
 import { createHash } from "node:crypto";
 import { existsSync, statSync } from "node:fs";
 import { createRequire } from "node:module";
-import { basename, delimiter, extname, isAbsolute, resolve } from "node:path";
+import { basename, delimiter, extname, isAbsolute, resolve, win32 } from "node:path";
 import { VERSION } from "@earendil-works/pi-coding-agent";
 
 const require = createRequire(import.meta.url);
@@ -176,23 +176,57 @@ function resolveCommandIdentity(command: string, cwd: string, suppliedEnv?: Node
 	return `unresolved:${command}\0lookup:${fingerprint(`${cwd}\0${pathValue}\0${pathExt}`)}`;
 }
 
-function environmentIdentity(suppliedEnv?: NodeJS.ProcessEnv): string {
-	const env = suppliedEnv ?? process.env;
-	const entries = Object.keys(env).sort().flatMap((key) => {
-		const value = env[key];
-		if (value === undefined) return [];
-		return [[process.platform === "win32" ? key.toLowerCase() : key, value] as const];
+function isUrlLike(value: string): boolean {
+	return /^[A-Za-z][A-Za-z\d+.-]*:/.test(value);
+}
+
+function resolvePrefixResourceIdentity(value: string, cwd: string): string {
+	const driveMatch = /^([A-Za-z]):(.*)$/.exec(value);
+	if (driveMatch) {
+		const drive = driveMatch[1]!.toUpperCase();
+		const tail = driveMatch[2]!;
+		if (/^[\\/]/.test(tail)) {
+			const normalized = `${drive}:${tail.replaceAll("\\", "/")}`;
+			return process.platform === "win32" ? fileIdentity(win32.resolve(value)) : `windows-path:${normalized}`;
+		}
+		const resolvedCwd = process.platform === "win32" ? win32.resolve(cwd) : resolve(cwd);
+		const resolved = process.platform === "win32" ? fileIdentity(win32.resolve(cwd, value)) : `${drive}:${tail}`;
+		return `windows-drive-relative:${resolvedCwd}:${resolved}`;
+	}
+	if (/^(?:\\\\|\/\/)[^\\/]/.test(value)) {
+		const normalized = value.replaceAll("\\", "/").replace(/^\/+/, "//");
+		return process.platform === "win32" ? fileIdentity(win32.resolve(value)) : `windows-unc:${normalized}`;
+	}
+	if (isUrlLike(value)) return value;
+	return fileIdentity(resolve(cwd, value));
+}
+
+function resolveVersionPrefixIdentity(args: readonly string[], cwd: string): string[] {
+	// Wrapper option grammars are not known here. Conservatively treat every
+	// positional argument and inline option value as a cwd-resolved resource;
+	// this prevents relative CLI/env-file aliases from sharing compatibility.
+	let optionsTerminated = false;
+	return args.map((arg) => {
+		if (arg === "--version") return arg;
+		if (arg === "--" && !optionsTerminated) {
+			optionsTerminated = true;
+			return arg;
+		}
+		if (optionsTerminated || !arg.startsWith("-")) return resolvePrefixResourceIdentity(arg, cwd);
+
+		const equalsIndex = arg.indexOf("=");
+		if (equalsIndex === -1) return arg;
+		const option = arg.slice(0, equalsIndex);
+		const value = arg.slice(equalsIndex + 1);
+		return value ? `${option}=${resolvePrefixResourceIdentity(value, cwd)}` : arg;
 	});
-	return fingerprint(JSON.stringify(entries));
 }
 
 export function buildPiVersionProbeCacheKey(command: string, args: string[], cwd: string, env?: NodeJS.ProcessEnv): string {
 	const resolvedCwd = resolve(cwd);
 	const identity = JSON.stringify({
 		command: resolveCommandIdentity(command, resolvedCwd, env),
-		cwd: resolvedCwd,
-		args,
-		environment: environmentIdentity(env),
+		args: resolveVersionPrefixIdentity(args, resolvedCwd),
 	});
 	return `pi-version-probe:v1:${fingerprint(identity)}`;
 }

--- a/src/runtime/pi-version.ts
+++ b/src/runtime/pi-version.ts
@@ -12,6 +12,7 @@ export const HOST_PI_VERSION = VERSION;
 export const MINIMUM_WORKER_PI_VERSION = "0.80.6";
 const DEFAULT_PROBE_TIMEOUT_MS = 5_000;
 export const SUCCESSFUL_PROBE_CACHE_TTL_MS = 30_000;
+export const MAX_COMPLETED_PROBE_CACHE_ENTRIES = 64;
 const PROBE_OUTPUT_LIMIT_BYTES = 64 * 1024;
 const DIAGNOSTIC_LIMIT_CHARS = 500;
 
@@ -59,10 +60,20 @@ export interface PiVersionProbeResult {
 
 export type ProbeWorkerPiVersion = (options: PiVersionProbeOptions) => Promise<PiVersionProbeResult>;
 
-interface ProbeCacheEntry {
-	promise: Promise<PiVersionProbeResult>;
-	completedAt?: number;
+type PiVersionCompatibilityResult = Omit<PiVersionProbeResult, "command" | "versionArgs">;
+
+interface PendingProbeCacheEntry {
+	state: "pending";
+	promise: Promise<PiVersionCompatibilityResult>;
 }
+
+interface CompletedProbeCacheEntry {
+	state: "completed";
+	result: PiVersionCompatibilityResult;
+	completedAt: number;
+}
+
+type ProbeCacheEntry = PendingProbeCacheEntry | CompletedProbeCacheEntry;
 
 const probeCache = new Map<string, ProbeCacheEntry>();
 
@@ -192,13 +203,15 @@ function appendCapped(current: string, chunk: unknown): string {
 	return current + Buffer.from(String(chunk)).subarray(0, remaining).toString();
 }
 
-function diagnostic(value: string): string {
-	const trimmed = value.trim();
+function diagnostic(value: string, sensitiveArgs: readonly string[] = []): string {
+	let redacted = value;
+	const uniqueSensitiveArgs = [...new Set(sensitiveArgs.filter((arg) => arg.length > 0 && arg !== "--version"))]
+		.sort((left, right) => right.length - left.length);
+	for (const arg of uniqueSensitiveArgs) {
+		redacted = redacted.split(arg).join("[redacted]");
+	}
+	const trimmed = redacted.trim();
 	return trimmed.length <= DIAGNOSTIC_LIMIT_CHARS ? trimmed : `${trimmed.slice(0, DIAGNOSTIC_LIMIT_CHARS)}… [truncated]`;
-}
-
-function formatArgv(command: string, args: string[]): string {
-	return diagnostic([command, ...args].map((arg) => JSON.stringify(arg)).join(" "));
 }
 
 function delay(ms: number): Promise<void> {
@@ -322,23 +335,62 @@ export const runPiVersionCommand: RunPiVersionCommand = ({ command, args, cwd, e
 	});
 });
 
+function materializeProbeResult(
+	command: string,
+	versionArgs: readonly string[],
+	compatibility: PiVersionCompatibilityResult,
+): PiVersionProbeResult {
+	return {
+		command,
+		versionArgs: [...versionArgs],
+		...compatibility,
+	};
+}
+
+function purgeExpiredCompletedEntries(now: number): void {
+	for (const [key, entry] of probeCache) {
+		if (entry.state === "completed" && now - entry.completedAt >= SUCCESSFUL_PROBE_CACHE_TTL_MS) {
+			probeCache.delete(key);
+		}
+	}
+}
+
+function enforceCompletedEntryLimit(): void {
+	let completedCount = 0;
+	for (const entry of probeCache.values()) {
+		if (entry.state === "completed") completedCount += 1;
+	}
+	while (completedCount > MAX_COMPLETED_PROBE_CACHE_ENTRIES) {
+		let oldestKey: string | undefined;
+		let oldestCompletedAt = Number.POSITIVE_INFINITY;
+		for (const [key, entry] of probeCache) {
+			if (entry.state === "completed" && entry.completedAt < oldestCompletedAt) {
+				oldestKey = key;
+				oldestCompletedAt = entry.completedAt;
+			}
+		}
+		if (oldestKey === undefined) return;
+		probeCache.delete(oldestKey);
+		completedCount -= 1;
+	}
+}
+
 export async function probeWorkerPiVersion(
 	options: PiVersionProbeOptions,
 	run: RunPiVersionCommand = runPiVersionCommand,
 ): Promise<PiVersionProbeResult> {
+	purgeExpiredCompletedEntries(Date.now());
 	const command = options.command ?? "pi";
 	const versionArgs = buildPiVersionArgs(options.baseArgs);
 	const key = buildPiVersionProbeCacheKey(command, versionArgs, options.cwd, options.env);
 	const existing = probeCache.get(key);
-	if (existing && (existing.completedAt === undefined || Date.now() - existing.completedAt < SUCCESSFUL_PROBE_CACHE_TTL_MS)) {
-		return existing.promise;
+	if (existing) {
+		const compatibility = existing.state === "completed" ? existing.result : await existing.promise;
+		return materializeProbeResult(command, versionArgs, compatibility);
 	}
-	if (existing) probeCache.delete(key);
 
-	const pending = (async (): Promise<PiVersionProbeResult> => {
+	const pending = (async (): Promise<PiVersionCompatibilityResult> => {
 		const common = {
-			command,
-			versionArgs,
 			hostVersion: HOST_PI_VERSION,
 			minimumVersion: MINIMUM_WORKER_PI_VERSION,
 		};
@@ -354,24 +406,23 @@ export async function probeWorkerPiVersion(
 		} catch (error) {
 			result = { stdout: "", stderr: "", code: null, error: error instanceof Error ? error : new Error(String(error)) };
 		}
-		const argv = formatArgv(command, versionArgs);
 		if (result.error || result.code !== 0) {
-			const detail = diagnostic(result.error?.message ?? (result.stderr.trim() || `exit code ${result.code}`));
+			const detail = diagnostic(result.error?.message ?? (result.stderr.trim() || `exit code ${result.code}`), versionArgs);
 			return {
 				...common,
 				supported: false,
 				mismatch: false,
-				message: `Cannot launch Pi worker: failed to run ${basename(command)} --version (argv: ${argv}; ${detail}). Install Pi ${MINIMUM_WORKER_PI_VERSION} or newer, or fix rpc.command.`,
+				message: `Cannot launch Pi worker: failed to run ${basename(command)} --version (${detail}). Install Pi ${MINIMUM_WORKER_PI_VERSION} or newer, or fix rpc.command.`,
 			};
 		}
 		const parsed = parsePiVersion(result.stdout);
 		if (!parsed) {
-			const shown = diagnostic(result.stdout) || "no version output";
+			const shown = diagnostic(result.stdout, versionArgs) || "no version output";
 			return {
 				...common,
 				supported: false,
 				mismatch: false,
-				message: `Cannot launch Pi worker: ${basename(command)} --version returned an unparseable version (${JSON.stringify(shown)}; argv: ${argv}). Install Pi ${MINIMUM_WORKER_PI_VERSION} or newer, or fix rpc.command.`,
+				message: `Cannot launch Pi worker: ${basename(command)} --version returned an unparseable version (${JSON.stringify(shown)}). Install Pi ${MINIMUM_WORKER_PI_VERSION} or newer, or fix rpc.command.`,
 			};
 		}
 		const minimum = parsePiVersion(MINIMUM_WORKER_PI_VERSION)!;
@@ -386,16 +437,37 @@ export async function probeWorkerPiVersion(
 			}),
 		};
 	})();
-	const entry: ProbeCacheEntry = { promise: pending };
+	const entry: PendingProbeCacheEntry = { state: "pending", promise: pending };
 	probeCache.set(key, entry);
-	const result = await pending;
+	const compatibility = await pending;
 	if (probeCache.get(key) === entry) {
-		if (result.supported) entry.completedAt = Date.now();
-		else probeCache.delete(key);
+		if (compatibility.supported) {
+			probeCache.set(key, {
+				state: "completed",
+				result: compatibility,
+				completedAt: Date.now(),
+			});
+			enforceCompletedEntryLimit();
+		} else {
+			probeCache.delete(key);
+		}
 	}
-	return result;
+	return materializeProbeResult(command, versionArgs, compatibility);
 }
 
 export function clearPiVersionProbeCache(): void {
 	probeCache.clear();
 }
+
+function snapshotProbeCache(): unknown[] {
+	return Array.from(probeCache, ([key, entry]) => entry.state === "pending"
+		? { key, state: entry.state }
+		: {
+			key,
+			state: entry.state,
+			completedAt: entry.completedAt,
+			result: { ...entry.result },
+		});
+}
+
+export const _testing = { snapshotProbeCache };

--- a/src/runtime/rpc-client.ts
+++ b/src/runtime/rpc-client.ts
@@ -192,8 +192,8 @@ export class RpcClient {
 		return this.send<unknown>({ type: "get_messages" });
 	}
 
-	async getSessionStats(): Promise<RpcSessionStats> {
-		return this.send<RpcSessionStats>({ type: "get_session_stats" });
+	async getSessionStats(signal?: AbortSignal): Promise<RpcSessionStats> {
+		return this.send<RpcSessionStats>({ type: "get_session_stats" }, signal);
 	}
 
 	async send<TData>(command: SupportedRpcCommand, signal?: AbortSignal): Promise<TData> {
@@ -206,12 +206,27 @@ export class RpcClient {
 		const body = `${JSON.stringify(payload)}\n`;
 
 		return new Promise<TData>((resolve, reject) => {
-			this.pending.set(id, { resolve, reject });
-
+			let settled = false;
+			const cleanup = (): void => signal?.removeEventListener("abort", onAbort);
+			const deferred: Deferred<TData> = {
+				resolve: (value) => {
+					if (settled) return;
+					settled = true;
+					cleanup();
+					resolve(value);
+				},
+				reject: (error) => {
+					if (settled) return;
+					settled = true;
+					cleanup();
+					reject(error);
+				},
+			};
 			const onAbort = (): void => {
 				this.pending.delete(id);
-				reject(new Error(`RPC command aborted: ${command.type}`));
+				deferred.reject(new Error(`RPC command aborted: ${command.type}`));
 			};
+			this.pending.set(id, deferred);
 
 			if (signal) {
 				if (signal.aborted) {
@@ -222,12 +237,9 @@ export class RpcClient {
 			}
 
 			this.transport.stdin.write(body, (error) => {
-				if (signal) {
-					signal.removeEventListener("abort", onAbort);
-				}
 				if (!error) return;
 				this.pending.delete(id);
-				reject(error instanceof Error ? error : new Error(String(error)));
+				deferred.reject(error instanceof Error ? error : new Error(String(error)));
 			});
 		});
 	}

--- a/src/runtime/worker-manager.ts
+++ b/src/runtime/worker-manager.ts
@@ -1,4 +1,5 @@
 import { EventEmitter } from "node:events";
+import { createDeferred } from "./deferred.js";
 import {
 	createThinkingClampedEvent,
 	createWorkerExitEvent,
@@ -15,6 +16,7 @@ import {
 } from "./pi-version.js";
 import {
 	spawnWorkerProcess,
+	WORKER_PROCESS_DISPOSE_MAX_MS,
 	type SpawnWorkerProcess,
 	type WorkerProcessHandle,
 	type WorkerProcessOptions,
@@ -59,6 +61,7 @@ export interface LaunchWorkerOptions {
 	baseArgs?: string[];
 	extraArgs?: string[];
 	env?: NodeJS.ProcessEnv;
+	signal?: AbortSignal;
 }
 
 export interface ManagedWorkerRecord {
@@ -148,10 +151,47 @@ export interface WorkerLaunchSnapshot {
 	allowSkills: boolean;
 }
 
+export interface WorkerManagerLifecycleOptions {
+	abortTimeoutMs?: number;
+	handleDisposeTimeoutMs?: number;
+}
+
 interface PendingWorkerLaunch {
 	cancelled: boolean;
 	handle?: WorkerProcessHandle;
 	promise?: Promise<ManagedWorkerRecord>;
+	disposePromise?: Promise<void>;
+	abortController: AbortController;
+}
+
+const DEFAULT_ABORT_TIMEOUT_MS = 1_000;
+export const DEFAULT_HANDLE_DISPOSE_TIMEOUT_MS = WORKER_PROCESS_DISPOSE_MAX_MS + 250;
+
+function launchAbortError(workerId: string): Error {
+	const error = new Error(`Worker launch aborted for ${workerId}`);
+	error.name = "AbortError";
+	return error;
+}
+
+function throwIfLaunchAborted(workerId: string, signal: AbortSignal | undefined): void {
+	if (signal?.aborted) throw launchAbortError(workerId);
+}
+
+async function waitForAbort<T>(
+	promise: Promise<T>,
+	signal: AbortSignal | undefined,
+	createAbortError: () => Error,
+): Promise<T> {
+	if (!signal) return promise;
+	if (signal.aborted) throw createAbortError();
+	const { promise: aborted, reject } = createDeferred<never>();
+	const onAbort = () => reject(createAbortError());
+	signal.addEventListener("abort", onAbort, { once: true });
+	try {
+		return await Promise.race([promise, aborted]);
+	} finally {
+		signal.removeEventListener("abort", onAbort);
+	}
 }
 
 interface WorkerRuntimeRecord extends ManagedWorkerRecord {
@@ -368,11 +408,15 @@ export class WorkerManager {
 	private readonly pendingLaunches = new Map<string, PendingWorkerLaunch>();
 	private readonly emitter = new EventEmitter();
 	private readonly probeVersion: ProbeWorkerPiVersion;
+	private readonly abortTimeoutMs: number;
+	private readonly handleDisposeTimeoutMs: number;
 	private disposed = false;
+	private disposePromise?: Promise<void>;
 
 	constructor(
 		private readonly spawnProcess: SpawnWorkerProcess = spawnWorkerProcess,
 		probeVersion?: ProbeWorkerPiVersion,
+		lifecycle: WorkerManagerLifecycleOptions = {},
 	) {
 		// Tests and embedders that inject a fake process launcher must not
 		// accidentally execute the developer's machine-global `pi` binary.
@@ -387,6 +431,8 @@ export class WorkerManager {
 				supported: true,
 				mismatch: false,
 			}));
+		this.abortTimeoutMs = lifecycle.abortTimeoutMs ?? DEFAULT_ABORT_TIMEOUT_MS;
+		this.handleDisposeTimeoutMs = lifecycle.handleDisposeTimeoutMs ?? DEFAULT_HANDLE_DISPOSE_TIMEOUT_MS;
 	}
 
 	onEvent(listener: (worker: ManagedWorkerRecord, event: NormalizedWorkerEvent) => void): () => void {
@@ -400,6 +446,11 @@ export class WorkerManager {
 	}
 
 	launchWorker(options: LaunchWorkerOptions): Promise<ManagedWorkerRecord> {
+		try {
+			throwIfLaunchAborted(options.workerId, options.signal);
+		} catch (error) {
+			return Promise.reject(error);
+		}
 		if (this.disposed) {
 			return Promise.reject(new Error("WorkerManager is disposed; cannot launch workers"));
 		}
@@ -409,7 +460,7 @@ export class WorkerManager {
 
 		// Reserve the id synchronously, before version preflight yields, so two
 		// same-id callers cannot both reach spawn.
-		const pending: PendingWorkerLaunch = { cancelled: false };
+		const pending: PendingWorkerLaunch = { cancelled: false, abortController: new AbortController() };
 		this.pendingLaunches.set(options.workerId, pending);
 		const promise = this.launchReservedWorker(options, pending).finally(() => {
 			if (this.pendingLaunches.get(options.workerId) === pending) {
@@ -424,12 +475,15 @@ export class WorkerManager {
 		options: LaunchWorkerOptions,
 		pending: PendingWorkerLaunch,
 	): Promise<ManagedWorkerRecord> {
-		const version = await this.probeVersion({
+		const launchSignal = options.signal
+			? AbortSignal.any([options.signal, pending.abortController.signal])
+			: pending.abortController.signal;
+		const version = await waitForAbort(this.probeVersion({
 			command: options.command,
 			baseArgs: options.baseArgs,
 			cwd: options.cwd,
 			env: options.env,
-		});
+		}), launchSignal, () => launchAbortError(options.workerId));
 		if (pending.cancelled || this.disposed) {
 			throw new Error(`Worker launch cancelled for ${options.workerId}: WorkerManager is disposed`);
 		}
@@ -443,7 +497,7 @@ export class WorkerManager {
 				message: `Pi Agents Team: host Pi ${version.hostVersion} is launching worker Pi ${version.workerVersion} via ${version.command}; the supported version mismatch is non-fatal.`,
 			} satisfies WorkerPiVersionMismatchEvent);
 		}
-
+		throwIfLaunchAborted(options.workerId, launchSignal);
 		const handle = this.spawnProcess(createWorkerProcessOptions(options));
 		pending.handle = handle;
 		const client = new RpcClient(handle.transport);
@@ -516,12 +570,13 @@ export class WorkerManager {
 		});
 
 		try {
-			const state = await Promise.race([
+			const state = await waitForAbort(Promise.race([
 				this.refreshState(options.workerId),
 				exitPromise.then((exitInfo) => {
 					throw exitInfo.error ?? new Error("Worker exited before launch completed");
 				}),
-			]);
+			]), launchSignal, () => launchAbortError(options.workerId));
+			throwIfLaunchAborted(options.workerId, launchSignal);
 			launchCommitted = true;
 			this.detectThinkingClamp(record, state);
 			return this.snapshot(options.workerId)!;
@@ -529,13 +584,18 @@ export class WorkerManager {
 			for (const off of record.unsubscribers) off();
 			record.client.dispose("Worker launch failed");
 			this.workers.delete(options.workerId);
+			let cleanupError: unknown;
 			try {
-				await handle.dispose();
-			} catch {
-				// Best-effort cleanup after launch failure.
+				await this.disposePendingHandleBounded(pending, `launch cleanup for ${options.workerId}`);
+			} catch (disposeError) {
+				cleanupError = disposeError;
 			}
 			const errorMessage = error instanceof Error ? error.message : String(error);
-			throw new Error(`Worker launch failed for ${options.workerId}: ${errorMessage}`);
+			if (cleanupError) {
+				const cleanupMessage = cleanupError instanceof Error ? cleanupError.message : String(cleanupError);
+				throw new AggregateError([error, cleanupError], `Worker launch failed for ${options.workerId}: ${errorMessage}; ${cleanupMessage}`);
+			}
+			throw new Error(`Worker launch failed for ${options.workerId}: ${errorMessage}`, { cause: error });
 		}
 	}
 
@@ -568,7 +628,7 @@ export class WorkerManager {
 		this.workers.delete(workerId);
 	}
 
-	async reuseWorker(workerId: string, message: string, task: DelegatedTaskInput): Promise<void> {
+	prepareWorkerReuse(workerId: string, task: DelegatedTaskInput): ManagedWorkerRecord {
 		const record = this.requireWorker(workerId);
 		if (!REUSABLE_STATUSES.has(record.state.status)) {
 			throw new Error(
@@ -597,6 +657,11 @@ export class WorkerManager {
 		record.awaitingSettlement = false;
 		// Reuse keeps the same RPC session and launch-time model/thinking flags,
 		// so the post-launch clamp comparison remains valid for the reused task.
+		return this.snapshot(workerId)!;
+	}
+
+	async reuseWorker(workerId: string, message: string, task: DelegatedTaskInput): Promise<void> {
+		this.prepareWorkerReuse(workerId, task);
 		await this.promptWorker(workerId, message);
 	}
 
@@ -660,17 +725,21 @@ export class WorkerManager {
 		record.state.lastEventAt = timestamp;
 		record.state.lastSummary = buildSummary(record.state, record.textBuffer || "Aborted");
 		try {
-			await record.client.abort();
+			await this.withDeadline(record.client.abort(), this.abortTimeoutMs, `Abort RPC for ${workerId}`);
 		} catch (error) {
 			const abortMessage = error instanceof Error ? error.message : String(error);
-			let shutdownMessage: string | undefined;
+			let shutdownError: unknown;
 			try {
-				// TeamManager cannot reach its follow-up shutdown when abort rejects.
-				// Dispose here so operator cancellation never strands the RPC process.
-				await record.handle.dispose();
-			} catch (shutdownError) {
-				shutdownMessage = shutdownError instanceof Error ? shutdownError.message : String(shutdownError);
+				// TeamManager cannot reach its follow-up shutdown when abort rejects
+				// or hangs. Bounded disposal prevents either failure from stranding
+				// the cancellation call forever.
+				await this.disposeHandleBounded(record.handle, `abort cleanup for ${workerId}`);
+			} catch (errorDuringShutdown) {
+				shutdownError = errorDuringShutdown;
 			}
+			let shutdownMessage: string | undefined;
+			if (shutdownError instanceof Error) shutdownMessage = shutdownError.message;
+			else if (shutdownError !== undefined) shutdownMessage = String(shutdownError);
 			const detail = shutdownMessage
 				? `Abort RPC failed: ${abortMessage}; process shutdown also failed: ${shutdownMessage}`
 				: `Abort RPC failed: ${abortMessage}; worker process was terminated`;
@@ -696,7 +765,7 @@ export class WorkerManager {
 				error: detail,
 				timestamp: failedAt,
 			} satisfies NormalizedWorkerEvent);
-			throw new Error(detail);
+			throw new Error(detail, { cause: error });
 		}
 	}
 
@@ -707,9 +776,13 @@ export class WorkerManager {
 		return state;
 	}
 
-	async refreshStats(workerId: string): Promise<RpcSessionStats> {
+	async refreshStats(workerId: string, signal?: AbortSignal): Promise<RpcSessionStats> {
 		const record = this.requireWorker(workerId);
-		const stats = await record.client.getSessionStats();
+		const stats = await waitForAbort(record.client.getSessionStats(), signal, () => {
+			const error = new Error(`Worker reuse aborted for ${workerId}`);
+			error.name = "AbortError";
+			return error;
+		});
 		record.state.usage = this.updateUsage(record.state.usage, stats);
 		record.state.lastSummary = buildSummary(record.state, record.textBuffer);
 		return stats;
@@ -876,26 +949,68 @@ export class WorkerManager {
 
 	async shutdownWorker(workerId: string, signal: NodeJS.Signals = "SIGTERM"): Promise<void> {
 		const record = this.requireWorker(workerId);
-		await record.handle.dispose(signal);
+		await this.disposeHandleBounded(record.handle, `shutdown for ${workerId}`, signal);
 	}
 
-	async dispose(): Promise<void> {
-		if (this.disposed) {
-			await Promise.allSettled(Array.from(this.pendingLaunches.values(), (pending) => pending.promise));
-			return;
+	dispose(): Promise<void> {
+		if (!this.disposePromise) {
+			this.disposed = true;
+			this.disposePromise = this.disposeAll();
 		}
-		this.disposed = true;
+		return this.disposePromise;
+	}
+
+	private async disposeAll(): Promise<void> {
 		const pending = Array.from(this.pendingLaunches.values());
-		for (const launch of pending) launch.cancelled = true;
-		// A launch may already have spawned and be blocked in its initial RPC
-		// refresh. Closing its handle makes that launch settle before disposal does.
-		await Promise.allSettled(pending.map((launch) => launch.handle?.dispose()));
-		await Promise.allSettled(pending.map((launch) => launch.promise));
-		for (const record of this.workers.values()) {
-			record.closing = true;
+		for (const launch of pending) {
+			launch.cancelled = true;
+			launch.abortController.abort();
 		}
-		for (const workerId of Array.from(this.workers.keys())) {
-			await this.shutdownWorker(workerId);
+		const pendingHandles = new Set(
+			pending.flatMap((launch) => launch.handle ? [launch.handle] : []),
+		);
+		for (const record of this.workers.values()) record.closing = true;
+
+		const cleanupAttempts: Promise<void>[] = pending.map((launch) =>
+			this.disposePendingHandleBounded(launch, "pending launch cleanup"));
+		for (const record of this.workers.values()) {
+			if (pendingHandles.has(record.handle)) continue;
+			cleanupAttempts.push(this.disposeHandleBounded(record.handle, `worker cleanup for ${record.workerId}`));
+		}
+		const launchSettlements = pending.flatMap((launch) => launch.promise ? [launch.promise] : []);
+		const results = await Promise.allSettled([...cleanupAttempts, ...launchSettlements]);
+		const cleanupFailures = results
+			.slice(0, cleanupAttempts.length)
+			.flatMap((result) => result.status === "rejected" ? [result.reason] : []);
+		if (cleanupFailures.length > 0) {
+			throw new AggregateError(cleanupFailures, `WorkerManager disposal failed for ${cleanupFailures.length} cleanup attempt(s)`);
+		}
+	}
+
+	private disposePendingHandleBounded(pending: PendingWorkerLaunch, label: string): Promise<void> {
+		if (!pending.disposePromise) {
+			pending.disposePromise = pending.handle
+				? this.disposeHandleBounded(pending.handle, label)
+				: Promise.resolve();
+		}
+		return pending.disposePromise;
+	}
+
+	private async disposeHandleBounded(
+		handle: WorkerProcessHandle,
+		label: string,
+		signal: NodeJS.Signals = "SIGTERM",
+	): Promise<void> {
+		await this.withDeadline(handle.dispose(signal), this.handleDisposeTimeoutMs, label);
+	}
+
+	private async withDeadline<T>(operation: Promise<T>, timeoutMs: number, label: string): Promise<T> {
+		const { promise: timeout, reject } = createDeferred<never>();
+		const timer = setTimeout(() => reject(new Error(`${label} timed out after ${timeoutMs}ms`)), timeoutMs);
+		try {
+			return await Promise.race([operation, timeout]);
+		} finally {
+			clearTimeout(timer);
 		}
 	}
 

--- a/src/runtime/worker-manager.ts
+++ b/src/runtime/worker-manager.ts
@@ -778,11 +778,15 @@ export class WorkerManager {
 
 	async refreshStats(workerId: string, signal?: AbortSignal): Promise<RpcSessionStats> {
 		const record = this.requireWorker(workerId);
-		const stats = await waitForAbort(record.client.getSessionStats(), signal, () => {
-			const error = new Error(`Worker reuse aborted for ${workerId}`);
-			error.name = "AbortError";
-			return error;
-		});
+		let stats: RpcSessionStats;
+		try {
+			stats = await record.client.getSessionStats(signal);
+		} catch (error) {
+			if (!signal?.aborted) throw error;
+			const abortError = new Error(`Worker reuse aborted for ${workerId}`, { cause: error });
+			abortError.name = "AbortError";
+			throw abortError;
+		}
 		record.state.usage = this.updateUsage(record.state.usage, stats);
 		record.state.lastSummary = buildSummary(record.state, record.textBuffer);
 		return stats;
@@ -1020,11 +1024,19 @@ export class WorkerManager {
 			&& (
 				event.type === "worker_started"
 				|| event.type === "worker_running"
-				|| event.type === "worker_text_delta"
+				|| event.type === "worker_queue_updated"
+			)
+		) {
+			return;
+		}
+		if (
+			UNREACHABLE_TERMINAL_STATUSES.has(record.state.status)
+			&& record.state.status !== "aborted"
+			&& (
+				event.type === "worker_text_delta"
 				|| event.type === "worker_message"
 				|| event.type === "worker_tool_started"
 				|| event.type === "worker_tool_finished"
-				|| event.type === "worker_queue_updated"
 				|| event.type === "worker_agent_end"
 			)
 		) {
@@ -1062,7 +1074,7 @@ export class WorkerManager {
 				break;
 			case "worker_text_delta":
 				appendTranscriptText(record, event.delta);
-				record.state.status = "running";
+				if (!UNREACHABLE_TERMINAL_STATUSES.has(record.state.status)) record.state.status = "running";
 				record.state.lastSummary = buildSummary(record.state, record.textBuffer);
 				record.pendingTextDelta += event.delta;
 				record.pendingTextFlushAt = record.pendingTextFlushAt || event.timestamp;
@@ -1077,7 +1089,9 @@ export class WorkerManager {
 				if (assistantText) {
 					const finalAnswer = extractFinalAnswer(assistantText);
 					setTranscriptText(record, finalAnswer ?? assistantText);
-					record.state.pendingRelayQuestions = extractRelayQuestions(assistantText, record.state);
+					if (!UNREACHABLE_TERMINAL_STATUSES.has(record.state.status)) {
+						record.state.pendingRelayQuestions = extractRelayQuestions(assistantText, record.state);
+					}
 					record.state.lastSummary = buildSummary(record.state, assistantText);
 					this.appendConsole(record, {
 						ts: event.timestamp,
@@ -1113,7 +1127,7 @@ export class WorkerManager {
 				break;
 			}
 			case "worker_tool_started": {
-				record.state.status = "running";
+				if (!UNREACHABLE_TERMINAL_STATUSES.has(record.state.status)) record.state.status = "running";
 				record.state.lastToolName = event.toolName;
 				record.state.lastSummary = buildSummary(record.state, record.textBuffer);
 				this.flushPendingText(record);

--- a/src/runtime/worker-process.ts
+++ b/src/runtime/worker-process.ts
@@ -2,6 +2,7 @@ import { spawn as nodeSpawn, type ChildProcessWithoutNullStreams } from "node:ch
 import { EventEmitter } from "node:events";
 import { createRequire } from "node:module";
 import type { Readable, Writable } from "node:stream";
+import { createDeferred } from "./deferred.js";
 import type { ThinkingLevel, WorkerExtensionMode, WorkerProjectTrustOverride } from "../types.js";
 
 const require = createRequire(import.meta.url);
@@ -71,11 +72,96 @@ export interface WorkerProcessHandle {
 
 export type SpawnWorkerProcess = (options: WorkerProcessOptions) => WorkerProcessHandle;
 
+const PROCESS_TERMINATION_GRACE_MS = 250;
+const PROCESS_EXIT_WAIT_MS = 500;
+const WINDOWS_TREE_KILL_TIMEOUT_MS = 500;
+export const WORKER_PROCESS_DISPOSE_MAX_MS = WINDOWS_TREE_KILL_TIMEOUT_MS + PROCESS_EXIT_WAIT_MS;
+
+interface KillableProcess {
+	pid?: number;
+	kill(signal?: NodeJS.Signals): boolean;
+}
+
+interface TaskkillProcess extends KillableProcess {
+	once(event: "error", listener: () => void): unknown;
+	once(event: "close", listener: (code: number | null) => void): unknown;
+}
+
+type TaskkillSpawn = (command: string, args: string[], options: { stdio: "ignore" }) => TaskkillProcess;
+
+function delay(ms: number): Promise<void> {
+	const { promise, resolve } = createDeferred<void>();
+	setTimeout(resolve, ms);
+	return promise;
+}
+
+function tryKill(processHandle: KillableProcess, signal: NodeJS.Signals): void {
+	try {
+		processHandle.kill(signal);
+	} catch {
+		// The process may already have exited.
+	}
+}
+
+export async function terminateWindowsWorkerTree(
+	processHandle: KillableProcess,
+	spawnTaskkill: TaskkillSpawn = crossSpawn as unknown as TaskkillSpawn,
+	timeoutMs = WINDOWS_TREE_KILL_TIMEOUT_MS,
+): Promise<void> {
+	if (processHandle.pid === undefined) {
+		tryKill(processHandle, "SIGKILL");
+		return;
+	}
+	const { promise, resolve } = createDeferred<void>();
+	let killer: TaskkillProcess | undefined;
+	let settled = false;
+	const finish = (fallback: boolean) => {
+		if (settled) return;
+		settled = true;
+		clearTimeout(timeout);
+		if (fallback) tryKill(processHandle, "SIGKILL");
+		resolve();
+	};
+	const timeout = setTimeout(() => {
+		if (killer) tryKill(killer, "SIGKILL");
+		finish(true);
+	}, timeoutMs);
+	try {
+		killer = spawnTaskkill("taskkill", ["/pid", String(processHandle.pid), "/T", "/F"], { stdio: "ignore" });
+		killer.once("error", () => finish(true));
+		killer.once("close", (code) => finish(code !== 0));
+	} catch {
+		finish(true);
+	}
+	await promise;
+}
+
+function signalPosixProcessGroup(processHandle: KillableProcess, signal: NodeJS.Signals): boolean {
+	if (processHandle.pid === undefined) return processHandle.kill(signal);
+	try {
+		process.kill(-processHandle.pid, signal);
+		return true;
+	} catch {
+		return processHandle.kill(signal);
+	}
+}
+
+async function waitForExitBounded(exitPromise: Promise<ExitInfo>, timeoutMs: number): Promise<ExitInfo | undefined> {
+	return Promise.race([
+		exitPromise,
+		delay(timeoutMs).then(() => undefined),
+	]);
+}
+
 class NodeWorkerProcessHandle extends EventEmitter implements WorkerProcessHandle {
 	private stderr = "";
-	private exitPromise: Promise<ExitInfo>;
+	private readonly exitPromise: Promise<ExitInfo>;
+	private disposePromise?: Promise<ExitInfo>;
 
-	constructor(readonly transport: WorkerTransport) {
+	constructor(
+		readonly transport: WorkerTransport,
+		private readonly platform: NodeJS.Platform = process.platform,
+	) {
 		super();
 		this.transport.stderr.on("data", (chunk) => {
 			this.stderr += chunk.toString();
@@ -83,12 +169,12 @@ class NodeWorkerProcessHandle extends EventEmitter implements WorkerProcessHandl
 		this.transport.stdin.on("error", () => {
 			// Child process launch failures are reported through the process "error" event below.
 		});
-		this.exitPromise = new Promise<ExitInfo>((resolve) => {
-			this.transport.on("exit", (code, signal) => resolve({ code, signal }));
-			this.transport.on("error", (error) => {
-				this.stderr += `${error.message}\n`;
-				resolve({ code: null, signal: null, error });
-			});
+		const { promise, resolve } = createDeferred<ExitInfo>();
+		this.exitPromise = promise;
+		this.transport.on("exit", (code, signal) => resolve({ code, signal }));
+		this.transport.on("error", (error) => {
+			this.stderr += `${error.message}\n`;
+			resolve({ code: null, signal: null, error });
 		});
 	}
 
@@ -105,12 +191,26 @@ class NodeWorkerProcessHandle extends EventEmitter implements WorkerProcessHandl
 	}
 
 	kill(signal: NodeJS.Signals = "SIGTERM"): boolean {
-		return this.transport.kill(signal);
+		return this.platform === "win32"
+			? this.transport.kill(signal)
+			: signalPosixProcessGroup(this.transport, signal);
 	}
 
-	async dispose(signal: NodeJS.Signals = "SIGTERM"): Promise<ExitInfo> {
-		this.kill(signal);
-		return this.waitForExit();
+	dispose(signal: NodeJS.Signals = "SIGTERM"): Promise<ExitInfo> {
+		if (!this.disposePromise) this.disposePromise = this.disposeProcess(signal);
+		return this.disposePromise;
+	}
+
+	private async disposeProcess(signal: NodeJS.Signals): Promise<ExitInfo> {
+		if (this.platform === "win32") {
+			await terminateWindowsWorkerTree(this.transport);
+		} else {
+			this.kill(signal);
+			await delay(PROCESS_TERMINATION_GRACE_MS);
+			this.kill("SIGKILL");
+		}
+		return (await waitForExitBounded(this.exitPromise, PROCESS_EXIT_WAIT_MS))
+			?? { code: null, signal: "SIGKILL" };
 	}
 }
 
@@ -144,6 +244,7 @@ export function spawnWorkerProcess(options: WorkerProcessOptions): WorkerProcess
 		cwd: options.cwd,
 		env: options.env,
 		stdio: ["pipe", "pipe", "pipe"],
+		...(process.platform === "win32" ? {} : { detached: true }),
 	}) as ChildProcessWithoutNullStreams;
 
 	return new NodeWorkerProcessHandle(child as unknown as WorkerTransport);

--- a/src/types.ts
+++ b/src/types.ts
@@ -82,6 +82,15 @@ export const WORKER_STATUSES = [
 ] as const;
 export type WorkerStatus = (typeof WORKER_STATUSES)[number];
 
+export const PERSISTED_TERMINAL_WORKER_STATUSES = [
+	"idle",
+	"completed",
+	"aborted",
+	"error",
+	"exited",
+] as const satisfies readonly WorkerStatus[];
+export type PersistedTerminalWorkerStatus = (typeof PERSISTED_TERMINAL_WORKER_STATUSES)[number];
+
 export function compareWorkerIds(a: string, b: string): number {
 	const am = /^w(\d+)$/.exec(a);
 	const bm = /^w(\d+)$/.exec(b);
@@ -424,9 +433,11 @@ export interface TeamConfig {
 	profiles: TeamProfileSpec[];
 }
 
-export interface CompactPersistedWorkerSummary {
+export interface CompactPersistedWorkerSummary<
+	Status extends PersistedTerminalWorkerStatus = PersistedTerminalWorkerStatus,
+> {
 	headline: string;
-	status: WorkerStatus;
+	status: Status;
 	readFiles: string[];
 	changedFiles: string[];
 	risks: string[];
@@ -434,15 +445,20 @@ export interface CompactPersistedWorkerSummary {
 	updatedAt: number;
 }
 
-export interface CompactPersistedWorker {
+interface CompactPersistedWorkerForStatus<Status extends PersistedTerminalWorkerStatus> {
 	workerId: string;
 	profileName: string;
-	status: WorkerStatus;
+	status: Status;
 	startedAt: number;
 	lastEventAt: number;
-	lastSummary?: CompactPersistedWorkerSummary;
+	lastSummary?: CompactPersistedWorkerSummary<Status>;
 	usage: WorkerUsageStats;
 }
+
+/** A wire worker whose optional summary must carry the worker's exact status. */
+export type CompactPersistedWorker = {
+	[Status in PersistedTerminalWorkerStatus]: CompactPersistedWorkerForStatus<Status>;
+}[PersistedTerminalWorkerStatus];
 
 export type TeamPersistenceRecord =
 	| {

--- a/tests/control-plane/extension-wiring.test.ts
+++ b/tests/control-plane/extension-wiring.test.ts
@@ -8,6 +8,13 @@ import extension, { _testing } from "../../extensions/pi-agent-team/index";
 import { createDefaultTeamState, DEFAULT_TEAM_CONFIG } from "../../src/config";
 import { TeamManager, type AgentResult } from "../../src/control-plane/team-manager";
 import { restorePersistedTeamState } from "../../src/control-plane/persistence";
+import {
+	WorkerManager,
+	type LaunchWorkerOptions,
+	type ManagedWorkerRecord,
+	type WorkerLaunchSnapshot,
+} from "../../src/runtime/worker-manager";
+import type { RpcSessionStats } from "../../src/runtime/rpc-client";
 import type { PersistedTeamState, WorkerRuntimeState } from "../../src/types";
 
 interface RegisteredTool {
@@ -73,54 +80,6 @@ function assistantMessage(text: string): Parameters<SessionManager["appendMessag
 	};
 }
 
-test("persistence tail discovery stops at ambiguous valid siblings", () => {
-	const customType = DEFAULT_TEAM_CONFIG.persistence.stateCustomType;
-	const record = (recordId: string) => ({
-		version: 2, kind: "worker_terminal", recordId,
-		worker: {
-			workerId: recordId, profileName: "fixer", status: "completed",
-			startedAt: 1, lastEventAt: 2,
-			usage: { turns: 0, inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0, costUsd: 0 },
-		},
-	});
-	const anchor = { type: "message", id: "anchor", parentId: null };
-	const siblings = ["left", "right"].map((id) => ({
-		type: "custom", id, parentId: "anchor", customType, data: record(id),
-	}));
-	const branch = _testing.activeBranchWithPersistenceTail({
-		getLeafId: () => "anchor",
-		getBranch: () => [anchor],
-		getEntries: () => [anchor, ...siblings],
-	}, customType);
-	assert.deepEqual(branch, [anchor], "neither sibling is an authoritative continuation of the active branch");
-});
-
-test("persistence tail discovery indexes a large tail in one linear pass", () => {
-	const customType = DEFAULT_TEAM_CONFIG.persistence.stateCustomType;
-	const count = 20_000;
-	let parentReads = 0;
-	const entries = Array.from({ length: count }, (_, index) => ({
-		type: "custom",
-		id: `record-${index}`,
-		get parentId() { parentReads += 1; return index === 0 ? "anchor" : `record-${index - 1}`; },
-		customType,
-		data: {
-			version: 2, kind: "worker_terminal", recordId: `record-${index}`,
-			worker: {
-				workerId: `worker-${index}`, profileName: "fixer", status: "completed",
-				startedAt: 1, lastEventAt: 2,
-				usage: { turns: 0, inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0, costUsd: 0 },
-			},
-		},
-	}));
-	const branch = _testing.activeBranchWithPersistenceTail({
-		getLeafId: () => "anchor",
-		getBranch: () => [{ type: "message", id: "anchor", parentId: null }],
-		getEntries: () => entries,
-	}, customType);
-	assert.equal(branch.length, count + 1);
-	assert.ok(parentReads <= count * 2, `parentId was read ${parentReads} times for ${count} entries`);
-});
 
 test("extension mismatch notifier emits exactly one non-fatal session warning", () => {
 	const warnings: string[] = [];
@@ -1344,8 +1303,8 @@ test("tree away and back restores fresh and reused running workers as detached w
 			recordId: "malformed-shadow",
 			worker: {},
 		});
-		sessionManager.branch(anchorId);
-		await handlers.get("session_tree")?.({ oldLeafId: awayLeafId, newLeafId: anchorId }, ctx);
+		sessionManager.branch(originLeafId);
+		await handlers.get("session_tree")?.({ oldLeafId: awayLeafId, newLeafId: originLeafId }, ctx);
 		const restoredStatus = await statusTool.execute!("call", {});
 		const restoredWorkers: WorkerRuntimeState[] = restoredStatus.details.workers;
 		assert.deepEqual(restoredWorkers.map((item) => item.workerId).sort(), ["w-fresh", "w-reused"]);
@@ -1357,6 +1316,169 @@ test("tree away and back restores fresh and reused running workers as detached w
 	} finally {
 		TeamManager.prototype.dispose = originalDispose;
 		TeamManager.prototype.onStateChange = originalOnStateChange;
+	}
+});
+
+test("extension durably checkpoints actual fresh and idle-reuse transitions before prompt and disk reopen restores exited", async () => {
+	interface FakeWorker {
+		state: WorkerRuntimeState;
+		launch: LaunchWorkerOptions;
+	}
+	const fakeWorkers = new WeakMap<WorkerManager, Map<string, FakeWorker>>();
+	let activeSessionManager: SessionManager | undefined;
+	const promptTitles: string[] = [];
+	const originalLaunchWorker = WorkerManager.prototype.launchWorker;
+	const originalGetWorker = WorkerManager.prototype.getWorker;
+	const originalGetLaunchSnapshot = WorkerManager.prototype.getLaunchSnapshot;
+	const originalRefreshStats = WorkerManager.prototype.refreshStats;
+	const originalPrepareWorkerReuse = WorkerManager.prototype.prepareWorkerReuse;
+	const originalPromptWorker = WorkerManager.prototype.promptWorker;
+	try {
+		WorkerManager.prototype.launchWorker = async function (options): Promise<ManagedWorkerRecord> {
+			const state = structuredClone(makeWidgetState().activeWorkers.w1!);
+			state.workerId = options.workerId;
+			state.profileName = options.profileName;
+			state.status = "starting";
+			state.currentTask = options.task;
+			state.lastSummary = undefined;
+			const workers = fakeWorkers.get(this) ?? new Map<string, FakeWorker>();
+			workers.set(options.workerId, { state, launch: options });
+			fakeWorkers.set(this, workers);
+			return { workerId: options.workerId, state } as unknown as ManagedWorkerRecord;
+		};
+		WorkerManager.prototype.getWorker = function (workerId): ManagedWorkerRecord | undefined {
+			const state = fakeWorkers.get(this)?.get(workerId)?.state;
+			return state ? { workerId, state } as unknown as ManagedWorkerRecord : undefined;
+		};
+		WorkerManager.prototype.getLaunchSnapshot = function (workerId): WorkerLaunchSnapshot | undefined {
+			const launch = fakeWorkers.get(this)?.get(workerId)?.launch;
+			if (!launch) return undefined;
+			return {
+				cwd: launch.cwd,
+				command: launch.command,
+				baseArgs: launch.baseArgs,
+				model: launch.model,
+				thinkingLevel: launch.thinkingLevel,
+				tools: launch.tools,
+				workerExtensions: launch.workerExtensions,
+				systemPromptPath: launch.systemPromptPath,
+				extensionMode: launch.extensionMode,
+				projectTrust: launch.projectTrust,
+				allowSkills: launch.allowSkills === true,
+			};
+		};
+		WorkerManager.prototype.refreshStats = async function (): Promise<RpcSessionStats> {
+			return {
+				sessionId: "checkpoint-test",
+				userMessages: 1,
+				assistantMessages: 1,
+				toolCalls: 0,
+				toolResults: 0,
+				totalMessages: 2,
+				tokens: { input: 10, output: 5, cacheRead: 0, cacheWrite: 0, total: 15 },
+				cost: 0.01,
+				contextUsage: { tokens: 15, contextWindow: 200_000, percent: 0.01 },
+			};
+		};
+		WorkerManager.prototype.prepareWorkerReuse = function (workerId, task): ManagedWorkerRecord {
+			const worker = fakeWorkers.get(this)?.get(workerId);
+			assert.ok(worker);
+			worker.state.currentTask = task;
+			worker.state.status = "idle";
+			worker.state.finalAnswer = undefined;
+			worker.state.lastSummary = undefined;
+			worker.state.error = undefined;
+			return { workerId, state: worker.state } as unknown as ManagedWorkerRecord;
+		};
+		WorkerManager.prototype.promptWorker = async function (workerId): Promise<void> {
+			const worker = fakeWorkers.get(this)?.get(workerId);
+			assert.ok(worker);
+			assert.ok(activeSessionManager);
+			const checkpoint = restorePersistedTeamState(
+				activeSessionManager.getBranch(),
+				DEFAULT_TEAM_CONFIG.persistence.stateCustomType,
+			).activeWorkers[workerId];
+			assert.equal(checkpoint?.status, "exited", "durable detached checkpoint must exist before promptWorker");
+			promptTitles.push(worker.state.currentTask?.title ?? "");
+			worker.state.status = "idle";
+			worker.state.lastEventAt += 1;
+		};
+
+		for (const transition of ["fresh", "reuse"] as const) {
+			const sessionDir = mkdtempSync(join(tmpdir(), `pi-agent-team-${transition}-checkpoint-`));
+			const sessionManager = SessionManager.create(process.cwd(), sessionDir);
+			sessionManager.appendMessage(assistantMessage(`${transition} durable anchor`));
+			activeSessionManager = sessionManager;
+			promptTitles.length = 0;
+			const handlers = new Map<string, (...args: unknown[]) => Promise<unknown> | unknown>();
+			const tools: RegisteredTool[] = [];
+			extension({
+				registerTool(tool: RegisteredTool) {
+					tools.push(tool);
+				},
+				registerCommand() {},
+				on(event: string, handler: (...args: unknown[]) => Promise<unknown> | unknown) {
+					handlers.set(event, handler);
+				},
+				appendEntry(type: string, data: unknown) {
+					sessionManager.appendCustomEntry(type, data);
+				},
+				sendMessage() {},
+			} as unknown as ExtensionAPI);
+			const ctx = { cwd: process.cwd(), hasUI: false, sessionManager } as unknown as ExtensionContext;
+			await handlers.get("session_start")?.({ reason: "startup" }, ctx);
+			const delegate = tools.find((tool) => tool.name === "delegate_task")!;
+			const fresh = await delegate.execute!("fresh", {
+				title: transition === "fresh" ? "fresh transition" : "reuse seed",
+				goal: "exercise actual TeamManager fresh transition",
+				profileName: "reviewer",
+			}, new AbortController().signal, undefined, ctx);
+			if (transition === "reuse") {
+				await delegate.execute!("reuse", {
+					title: "reuse transition",
+					goal: "exercise actual TeamManager idle reuse transition",
+					profileName: "reviewer",
+					reuseWorkerId: fresh.details.worker.workerId,
+				}, new AbortController().signal, undefined, ctx);
+				assert.deepEqual(promptTitles, ["reuse seed", "reuse transition"]);
+			} else {
+				assert.deepEqual(promptTitles, ["fresh transition"]);
+			}
+
+			const sessionFile = sessionManager.getSessionFile();
+			assert.ok(sessionFile);
+			const reopened = SessionManager.open(sessionFile, sessionDir);
+			const reopenedHandlers = new Map<string, (...args: unknown[]) => Promise<unknown> | unknown>();
+			const reopenedTools: RegisteredTool[] = [];
+			extension({
+				registerTool(tool: RegisteredTool) {
+					reopenedTools.push(tool);
+				},
+				registerCommand() {},
+				on(event: string, handler: (...args: unknown[]) => Promise<unknown> | unknown) {
+					reopenedHandlers.set(event, handler);
+				},
+				appendEntry(type: string, data: unknown) {
+					reopened.appendCustomEntry(type, data);
+				},
+				sendMessage() {},
+			} as unknown as ExtensionAPI);
+			const reopenedCtx = { cwd: process.cwd(), hasUI: false, sessionManager: reopened } as unknown as ExtensionContext;
+			await reopenedHandlers.get("session_start")?.({ reason: "resume" }, reopenedCtx);
+			const status = await reopenedTools.find((tool) => tool.name === "agent_status")!.execute!("status", {
+				workerId: fresh.details.worker.workerId,
+			});
+			assert.equal(status.details.workers[0]?.status, "exited");
+			await reopenedHandlers.get("session_shutdown")?.({}, reopenedCtx);
+			await handlers.get("session_shutdown")?.({}, ctx);
+		}
+	} finally {
+		WorkerManager.prototype.launchWorker = originalLaunchWorker;
+		WorkerManager.prototype.getWorker = originalGetWorker;
+		WorkerManager.prototype.getLaunchSnapshot = originalGetLaunchSnapshot;
+		WorkerManager.prototype.refreshStats = originalRefreshStats;
+		WorkerManager.prototype.prepareWorkerReuse = originalPrepareWorkerReuse;
+		WorkerManager.prototype.promptWorker = originalPromptWorker;
 	}
 });
 
@@ -1372,6 +1494,12 @@ test("extension restores only the active Pi branch and does not checkpoint on st
 	};
 	const inactive = createDefaultTeamState();
 	inactive.activeWorkers.w9 = { ...active.activeWorkers.w1, workerId: "w9" };
+	const inactiveCompactChild = {
+		version: 2,
+		kind: "worker_terminal",
+		recordId: "inactive-compact-child",
+		worker: inactive.activeWorkers.w9,
+	};
 	let activeBranch = active;
 
 	extension({
@@ -1384,7 +1512,7 @@ test("extension restores only the active Pi branch and does not checkpoint on st
 	const ctx = {
 		cwd: process.cwd(), hasUI: false,
 		sessionManager: {
-			getEntries: () => [{ type: "custom", customType: DEFAULT_TEAM_CONFIG.persistence.stateCustomType, data: inactive }],
+			getEntries: () => [{ type: "custom", customType: DEFAULT_TEAM_CONFIG.persistence.stateCustomType, data: inactiveCompactChild }],
 			getBranch: () => [{ type: "custom", customType: DEFAULT_TEAM_CONFIG.persistence.stateCustomType, data: activeBranch }],
 		},
 	} as any;
@@ -1479,7 +1607,7 @@ test("extension emits plain widget lines in RPC mode even when hasUI=true", asyn
 			addAutocompleteProvider() {},
 		},
 		sessionManager: {
-			getEntries() {
+			getBranch() {
 				return [{
 					type: "custom",
 					customType: DEFAULT_TEAM_CONFIG.persistence.stateCustomType,

--- a/tests/control-plane/persistence.test.ts
+++ b/tests/control-plane/persistence.test.ts
@@ -4,9 +4,11 @@ import { createDefaultTeamState, DEFAULT_TEAM_CONFIG } from "../../src/config";
 import {
 	CompactPersistenceJournal,
 	compactPersistenceRecordPayloadBytes,
+	isRecognizedCompactPersistenceRecord,
 	markRestoredWorkersExited,
 	measureCompactPersistence,
 	restorePersistedTeamState,
+	restorePersistedTeamStateWithMeasurement,
 } from "../../src/control-plane/persistence";
 import type { TeamPersistenceRecord, WorkerRuntimeState } from "../../src/types";
 
@@ -59,6 +61,136 @@ function worker(status: WorkerRuntimeState["status"] = "running"): WorkerRuntime
 function entry(data: unknown) {
 	return { type: "custom", customType: DEFAULT_TEAM_CONFIG.persistence.stateCustomType, data };
 }
+
+test("canonical writer records are reader-recognized with invalid optional metrics omitted or bounded", () => {
+	const state = createDefaultTeamState();
+	const terminalWorker = worker("completed");
+	terminalWorker.usage.inputTokens = Number.POSITIVE_INFINITY;
+	terminalWorker.usage.contextTokens = -1;
+	terminalWorker.usage.contextWindow = Number.NaN;
+	terminalWorker.usage.contextPercent = Number.MAX_VALUE;
+	terminalWorker.usage.contextRemainingTokens = 321;
+	state.activeWorkers.w1 = terminalWorker;
+	const journal = new CompactPersistenceJournal();
+	journal.reset(createDefaultTeamState(), DEFAULT_TEAM_CONFIG);
+
+	const [terminal] = journal.collect(state, DEFAULT_TEAM_CONFIG);
+	assert.equal(terminal?.kind, "worker_terminal");
+	assert.ok(terminal && isRecognizedCompactPersistenceRecord(terminal));
+	if (terminal?.kind !== "worker_terminal") return;
+	assert.equal(terminal.worker.usage.inputTokens, 0);
+	assert.equal(terminal.worker.usage.contextTokens, undefined);
+	assert.equal(terminal.worker.usage.contextWindow, undefined);
+	assert.equal(terminal.worker.usage.contextPercent, Number.MAX_SAFE_INTEGER);
+	assert.equal(terminal.worker.usage.contextRemainingTokens, 321);
+
+	delete state.activeWorkers.w1;
+	const [prune] = journal.collect(state, DEFAULT_TEAM_CONFIG);
+	assert.equal(prune?.kind, "worker_pruned");
+	assert.ok(prune && isRecognizedCompactPersistenceRecord(prune));
+});
+
+test("terminal-to-live transition stages one exited checkpoint and live churn adds no records", () => {
+	const state = createDefaultTeamState();
+	state.activeWorkers.w1 = worker("idle");
+	const journal = new CompactPersistenceJournal();
+	journal.reset(state, DEFAULT_TEAM_CONFIG);
+
+	state.activeWorkers.w1.status = "running";
+	state.activeWorkers.w1.lastSummary!.status = "running";
+	const [checkpoint] = journal.prepare(state, DEFAULT_TEAM_CONFIG);
+	assert.equal(checkpoint?.kind, "worker_terminal");
+	if (checkpoint?.kind !== "worker_terminal") return;
+	assert.equal(checkpoint.worker.status, "exited");
+	assert.equal(checkpoint.worker.lastSummary?.status, "exited");
+	assert.deepEqual(journal.prepare(state, DEFAULT_TEAM_CONFIG), [checkpoint], "append failure retries the checkpoint exactly");
+
+	journal.commit(checkpoint);
+	state.activeWorkers.w1.lastToolName = "read";
+	state.activeWorkers.w1.finalAnswer = "still streaming";
+	state.activeWorkers.w1.lastEventAt += 1;
+	state.activeWorkers.w1.usage.inputTokens += 50;
+	assert.deepEqual(journal.prepare(state, DEFAULT_TEAM_CONFIG), [], "ordinary live updates do not churn checkpoints");
+});
+
+test("a real terminal record supersedes an uncommitted exited checkpoint", () => {
+	const state = createDefaultTeamState();
+	state.activeWorkers.w1 = worker("completed");
+	const journal = new CompactPersistenceJournal();
+	journal.reset(state, DEFAULT_TEAM_CONFIG);
+
+	state.activeWorkers.w1.status = "running";
+	state.activeWorkers.w1.lastSummary!.status = "running";
+	const [checkpoint] = journal.prepare(state, DEFAULT_TEAM_CONFIG);
+	assert.equal(checkpoint?.kind, "worker_terminal");
+	if (checkpoint?.kind !== "worker_terminal") return;
+	assert.equal(checkpoint.worker.status, "exited");
+
+	state.activeWorkers.w1.status = "error";
+	state.activeWorkers.w1.lastSummary!.status = "error";
+	state.activeWorkers.w1.lastSummary!.headline = "real terminal result";
+	state.activeWorkers.w1.usage.outputTokens += 10;
+	const replacements = journal.prepare(state, DEFAULT_TEAM_CONFIG);
+	assert.equal(replacements.length, 1);
+	const [terminal] = replacements;
+	assert.equal(terminal?.kind, "worker_terminal");
+	if (terminal?.kind !== "worker_terminal") return;
+	assert.equal(terminal.worker.status, "error");
+	assert.equal(terminal.worker.lastSummary?.headline, "real terminal result");
+	assert.notEqual(terminal.recordId, checkpoint.recordId);
+	journal.commit(terminal);
+	assert.deepEqual(journal.prepare(state, DEFAULT_TEAM_CONFIG), []);
+});
+
+test("combined restore inspects candidates once and serializes each recognized record once", () => {
+	const state = createDefaultTeamState();
+	state.activeWorkers.w1 = worker("completed");
+	const [record] = new CompactPersistenceJournal().collect(state, DEFAULT_TEAM_CONFIG);
+	assert.ok(record);
+
+	let candidateInspections = 0;
+	const observedRecord = new Proxy(record, {
+		getPrototypeOf(target) {
+			candidateInspections += 1;
+			return Reflect.getPrototypeOf(target);
+		},
+	});
+	let iteratorCalls = 0;
+	let yieldedEntries = 0;
+	const entries = {
+		*[Symbol.iterator]() {
+			iteratorCalls += 1;
+			yieldedEntries += 1;
+			yield entry(observedRecord);
+			yieldedEntries += 1;
+			yield entry({ version: 2, kind: "worker_terminal", recordId: "malformed", worker: {} });
+		},
+	};
+	const expectedPayloadBytes = compactPersistenceRecordPayloadBytes(record);
+	const originalStringify = JSON.stringify;
+	let serializations = 0;
+	JSON.stringify = ((...args: Parameters<typeof JSON.stringify>) => {
+		serializations += 1;
+		return originalStringify(...args);
+	}) as typeof JSON.stringify;
+	try {
+		const restored = restorePersistedTeamStateWithMeasurement(
+			entries,
+			DEFAULT_TEAM_CONFIG.persistence.stateCustomType,
+		);
+		assert.equal(restored.state.activeWorkers.w1?.status, "completed");
+		assert.deepEqual(restored.measurement, {
+			recordCount: 1,
+			payloadBytes: expectedPayloadBytes,
+		});
+	} finally {
+		JSON.stringify = originalStringify;
+	}
+	assert.equal(iteratorCalls, 1);
+	assert.equal(yieldedEntries, 2);
+	assert.equal(candidateInspections, 1);
+	assert.equal(serializations, 1);
+});
 
 test("compact journal ignores runtime churn and appends one capped allowlisted terminal record", () => {
 	const state = createDefaultTeamState();

--- a/tests/control-plane/persistence.test.ts
+++ b/tests/control-plane/persistence.test.ts
@@ -113,6 +113,27 @@ test("terminal-to-live transition stages one exited checkpoint and live churn ad
 	assert.deepEqual(journal.prepare(state, DEFAULT_TEAM_CONFIG), [], "ordinary live updates do not churn checkpoints");
 });
 
+test("committed detached checkpoints deduplicate unchanged live statuses", () => {
+	for (const status of ["starting", "running", "idle", "waiting_followup"] as const) {
+		const state = createDefaultTeamState();
+		state.activeWorkers.w1 = worker(status);
+		const journal = new CompactPersistenceJournal();
+		journal.reset(state, DEFAULT_TEAM_CONFIG);
+
+		const [checkpoint] = journal.prepareDetachedWorkers(state, DEFAULT_TEAM_CONFIG);
+		assert.equal(checkpoint?.kind, "worker_terminal", `${status}: expected detached checkpoint`);
+		if (!checkpoint) continue;
+		journal.commit(checkpoint);
+
+		assert.deepEqual(journal.prepare(state, DEFAULT_TEAM_CONFIG), [], `${status}: unchanged prepare must not append`);
+		assert.deepEqual(
+			journal.prepareDetachedWorkers(state, DEFAULT_TEAM_CONFIG),
+			[],
+			`${status}: committed durable baseline must deduplicate the next detached checkpoint`,
+		);
+	}
+});
+
 test("a real terminal record supersedes an uncommitted exited checkpoint", () => {
 	const state = createDefaultTeamState();
 	state.activeWorkers.w1 = worker("completed");

--- a/tests/control-plane/project-config-extension.test.ts
+++ b/tests/control-plane/project-config-extension.test.ts
@@ -618,12 +618,15 @@ test("ping_agents active returns restored registry snapshots after session_start
 	const ctx = {
 		...createSessionContext(cwd, notifications),
 		sessionManager: {
-			getEntries() {
+			getBranch() {
 				return [{
 					type: "custom",
 					customType: DEFAULT_TEAM_CONFIG.persistence.stateCustomType,
 					data: restored,
 				}];
+			},
+			getEntries() {
+				return this.getBranch();
 			},
 		},
 	} as any;
@@ -682,12 +685,15 @@ test("session lifecycle UI honors display.cost false", async () => {
 			setTitle() {},
 		},
 		sessionManager: {
-			getEntries() {
+			getBranch() {
 				return [{
 					type: "custom",
 					customType: DEFAULT_TEAM_CONFIG.persistence.stateCustomType,
 					data: state,
 				}];
+			},
+			getEntries() {
+				return this.getBranch();
 			},
 		},
 	} as any;

--- a/tests/control-plane/team-manager.test.ts
+++ b/tests/control-plane/team-manager.test.ts
@@ -968,6 +968,131 @@ async function createIdleReusableTeam(sessionStats?: Record<string, unknown> | (
 	return { teamManager, transports, workerId: first.worker.workerId };
 }
 
+test("TeamManager emits durable checkpoint state before fresh and reused prompt writes", async () => {
+	const order: string[] = [];
+	const transports: MockWorkerTransport[] = [];
+	const workerManager = new WorkerManager(() => {
+		const transport = new MockWorkerTransport({
+			onCommand(command) {
+				if (command.type === "prompt") order.push("prompt");
+			},
+		});
+		transports.push(transport);
+		return new MockWorkerHandle(transport);
+	});
+	const teamManager = new TeamManager({ workerManager });
+	teamManager.onBeforePrompt((state) => {
+		const worker = Object.values(state.activeWorkers)[0];
+		assert.ok(worker);
+		order.push(`checkpoint:${worker.currentTask?.title}`);
+	});
+
+	const first = await teamManager.delegateTask({
+		title: "Fresh checkpoint",
+		goal: "persist before fresh prompt",
+		profileName: "reviewer",
+		cwd: process.cwd(),
+	});
+	assert.deepEqual(order, ["checkpoint:Fresh checkpoint", "prompt"]);
+	await waitForMicrotasks();
+	await settleTransport(transports[0]);
+
+	order.length = 0;
+	await teamManager.delegateTask({
+		title: "Reuse checkpoint",
+		goal: "persist before reused prompt",
+		profileName: "reviewer",
+		cwd: process.cwd(),
+		reuseWorkerId: first.worker.workerId,
+	});
+	assert.deepEqual(order, ["checkpoint:Reuse checkpoint", "prompt"]);
+});
+
+test("reuse cancellation skips or interrupts stats without preparing a task or sending a prompt", {
+	timeout: 1_000,
+}, async () => {
+	const alreadyAbortedTeam = await createIdleReusableTeam();
+	const alreadyAbortedTransport = alreadyAbortedTeam.transports[0]!;
+	const alreadyAborted = new AbortController();
+	alreadyAborted.abort();
+	await assert.rejects(
+		alreadyAbortedTeam.teamManager.delegateTask({
+			title: "Never prepared",
+			goal: "already-aborted reuse",
+			profileName: "reviewer",
+			cwd: process.cwd(),
+			reuseWorkerId: alreadyAbortedTeam.workerId,
+		}, alreadyAborted.signal),
+		/abort/i,
+	);
+	assert.equal(alreadyAbortedTransport.commands.filter((command) => command.type === "get_session_stats").length, 0);
+	assert.equal(alreadyAbortedTransport.commands.filter((command) => command.type === "prompt").length, 1);
+	assert.equal(alreadyAbortedTeam.teamManager.snapshot().taskRegistry["t2"], undefined);
+	assert.equal(alreadyAbortedTeam.teamManager.getWorkerStatus(alreadyAbortedTeam.workerId)?.status, "idle");
+
+	const pendingStatsTransport = new MockWorkerTransport({ hangCommands: ["get_session_stats"] });
+	const pendingStatsManager = new WorkerManager(() => new MockWorkerHandle(pendingStatsTransport));
+	const pendingStatsTeam = new TeamManager({ workerManager: pendingStatsManager });
+	const first = await pendingStatsTeam.delegateTask({
+		title: "Reusable seed",
+		goal: "settle before cancelled reuse",
+		profileName: "reviewer",
+		cwd: process.cwd(),
+	});
+	await waitForMicrotasks();
+	await settleTransport(pendingStatsTransport);
+	const pendingAbort = new AbortController();
+	const pendingReuse = pendingStatsTeam.delegateTask({
+		title: "Never prepared after pending stats",
+		goal: "cancel pending stats",
+		profileName: "reviewer",
+		cwd: process.cwd(),
+		reuseWorkerId: first.worker.workerId,
+	}, pendingAbort.signal);
+	await waitForMicrotasks();
+	assert.equal(pendingStatsTransport.commands.filter((command) => command.type === "get_session_stats").length, 1);
+	pendingAbort.abort();
+	await assert.rejects(pendingReuse, /reuse aborted/i);
+	assert.equal(pendingStatsTransport.commands.filter((command) => command.type === "prompt").length, 1);
+	assert.equal(pendingStatsTeam.snapshot().taskRegistry["t2"], undefined);
+	assert.equal(pendingStatsTeam.getWorkerStatus(first.worker.workerId)?.currentTask?.title, "Reusable seed");
+	assert.equal(pendingStatsTeam.getWorkerStatus(first.worker.workerId)?.status, "idle");
+});
+
+test("listener-triggered abort after before-prompt checkpoint sends no fresh or reuse prompt", async () => {
+	const freshAbort = new AbortController();
+	const freshTransport = new MockWorkerTransport();
+	const freshTeam = new TeamManager({
+		workerManager: new WorkerManager(() => new MockWorkerHandle(freshTransport)),
+	});
+	freshTeam.onBeforePrompt(() => freshAbort.abort());
+	await assert.rejects(freshTeam.delegateTask({
+		title: "Fresh listener abort",
+		goal: "abort from checkpoint listener",
+		profileName: "reviewer",
+		cwd: process.cwd(),
+	}, freshAbort.signal), /abort/i);
+	assert.equal(freshTransport.commands.some((command) => command.type === "prompt"), false);
+	assert.deepEqual(freshTeam.listWorkers(), []);
+
+	const reuseTeamFixture = await createIdleReusableTeam();
+	const reuseAbort = new AbortController();
+	reuseTeamFixture.teamManager.onBeforePrompt((state) => {
+		const worker = state.activeWorkers[reuseTeamFixture.workerId];
+		if (worker?.currentTask?.title === "Reuse listener abort") reuseAbort.abort();
+	});
+	await assert.rejects(reuseTeamFixture.teamManager.delegateTask({
+		title: "Reuse listener abort",
+		goal: "abort after reuse checkpoint listener",
+		profileName: "reviewer",
+		cwd: process.cwd(),
+		reuseWorkerId: reuseTeamFixture.workerId,
+	}, reuseAbort.signal), /abort/i);
+	assert.equal(reuseTeamFixture.transports[0]!.commands.filter((command) => command.type === "prompt").length, 1);
+	assert.equal(reuseTeamFixture.teamManager.snapshot().taskRegistry["t2"], undefined);
+	assert.equal(reuseTeamFixture.teamManager.getWorkerStatus(reuseTeamFixture.workerId)?.status, "exited");
+});
+
 test("delegateTask with reuseWorkerId refreshes context and allows reuse below saturation thresholds", async () => {
 	const { teamManager, transports, workerId } = await createIdleReusableTeam({
 		sessionId: "mock-session",

--- a/tests/package-publish.test.ts
+++ b/tests/package-publish.test.ts
@@ -7,9 +7,15 @@ import { basename, join, resolve } from "node:path";
 import { spawnSync } from "node:child_process";
 
 const projectRoot = resolve(import.meta.dirname, "..");
-const PACKAGE_SUBPROCESS_TIMEOUT_MS = 45_000;
+const PACK_TIMEOUT_MS = 45_000;
+const OFFLINE_INSTALL_TIMEOUT_MS = 45_000;
+const CONSUMER_IMPORT_TIMEOUT_MS = 15_000;
+const SETUP_CLEANUP_MARGIN_MS = 30_000;
+const PACKAGE_TEST_TIMEOUT_MS = 150_000;
+const BUDGETED_TEST_DURATION_MS =
+	PACK_TIMEOUT_MS + OFFLINE_INSTALL_TIMEOUT_MS + CONSUMER_IMPORT_TIMEOUT_MS + SETUP_CLEANUP_MARGIN_MS;
 
-function runNpm(args: string[], cwd: string) {
+function runNpm(args: string[], cwd: string, timeoutMs: number) {
 	const npmCli = process.env.npm_execpath;
 	const command = npmCli ? process.execPath : process.platform === "win32" ? "npm.cmd" : "npm";
 	const commandArgs = npmCli ? [npmCli, ...args] : args;
@@ -17,17 +23,47 @@ function runNpm(args: string[], cwd: string) {
 		cwd,
 		encoding: "utf8",
 		env: { ...process.env, NO_UPDATE_NOTIFIER: "1" },
-		timeout: PACKAGE_SUBPROCESS_TIMEOUT_MS,
+		timeout: timeoutMs,
 	});
 	assert.equal(
 		result.status,
 		0,
-		`npm ${args.join(" ")} failed (timeout=${PACKAGE_SUBPROCESS_TIMEOUT_MS}ms; status=${String(result.status)}; signal=${String(result.signal)}; error=${result.error?.message ?? "none"})\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
+		`npm ${args.join(" ")} failed (timeout=${timeoutMs}ms; status=${String(result.status)}; signal=${String(result.signal)}; error=${result.error?.message ?? "none"})\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
 	);
 	return result;
 }
 
-test("a clean publish artifact installs and imports in an offline consumer", { timeout: 120_000 }, async () => {
+test("the package publish timeout covers every subprocess budget and filesystem cleanup", () => {
+	assert.ok(
+		PACKAGE_TEST_TIMEOUT_MS > BUDGETED_TEST_DURATION_MS,
+		`outer timeout (${PACKAGE_TEST_TIMEOUT_MS}ms) must exceed pack (${PACK_TIMEOUT_MS}ms) + offline install (${OFFLINE_INSTALL_TIMEOUT_MS}ms) + consumer import (${CONSUMER_IMPORT_TIMEOUT_MS}ms) + setup/cleanup (${SETUP_CLEANUP_MARGIN_MS}ms)`,
+	);
+});
+
+test("package docs pin Pi 0.80.6 and separate source, compiled, and published validation", async () => {
+	const [readme, contributing, operations, architecture] = await Promise.all(
+		["README.md", "CONTRIBUTING.md", "docs/operations.md", "docs/architecture.md"].map((path) =>
+			readFile(join(projectRoot, path), "utf8"),
+		),
+	);
+	const combinedDocumentation = [readme, contributing, operations, architecture].join("\n");
+
+	assert.doesNotMatch(combinedDocumentation, /\b0\.80\.7\b/);
+	assert.doesNotMatch(combinedDocumentation, /pi -e \.\/extensions\/index\.ts -p ["']\/team["']/);
+	assert.doesNotMatch(combinedDocumentation, /That smoke command exercises the shipped package entrypoint/);
+	assert.match(readme, /This checks the source path only; it does not validate the compiled or published package entrypoint\./);
+	assert.match(
+		contributing,
+		/Development validation uses exactly Pi `0\.80\.6`[\s\S]*Do not use `-p "\/team"` as an overlay check/,
+	);
+	assert.match(
+		operations,
+		/Check the source shim during development:[\s\S]*Check the compiled Pi entrypoint:[\s\S]*Check the published package contract/,
+	);
+	assert.match(architecture, /Repository development dependencies and validation use exactly Pi `0\.80\.6`/);
+});
+
+test("a clean publish artifact installs and imports in an offline consumer", { timeout: PACKAGE_TEST_TIMEOUT_MS }, async () => {
 	const temporaryRoot = await mkdtemp(join(tmpdir(), "pi-agents-team-publish-"));
 	const cleanSource = join(temporaryRoot, "source");
 	const artifacts = join(temporaryRoot, "artifacts");
@@ -45,7 +81,7 @@ test("a clean publish artifact installs and imports in an offline consumer", { t
 		await symlink(join(projectRoot, "node_modules"), join(cleanSource, "node_modules"), "junction");
 		assert.equal(existsSync(join(cleanSource, "dist")), false, "publish build must start without dist");
 
-		runNpm(["pack", "--pack-destination", artifacts, "--ignore-scripts=false"], cleanSource);
+		runNpm(["pack", "--pack-destination", artifacts, "--ignore-scripts=false"], cleanSource, PACK_TIMEOUT_MS);
 		const tarballs = (await readdir(artifacts)).filter((entry) => entry.endsWith(".tgz"));
 		assert.equal(tarballs.length, 1, "npm pack should create exactly one tarball");
 
@@ -65,6 +101,7 @@ test("a clean publish artifact installs and imports in an offline consumer", { t
 		runNpm(
 			["install", "--offline", "--ignore-scripts", "--no-package-lock", "--no-save", tarball],
 			consumer,
+			OFFLINE_INSTALL_TIMEOUT_MS,
 		);
 
 		const installedPackage = join(consumer, "node_modules", "pi-agents-team");
@@ -87,12 +124,12 @@ test("a clean publish artifact installs and imports in an offline consumer", { t
 		const imported = spawnSync(
 			process.execPath,
 			["--input-type=module", "--eval", 'import extension from "pi-agents-team"; if (typeof extension !== "function") process.exit(1)'],
-			{ cwd: consumer, encoding: "utf8", timeout: PACKAGE_SUBPROCESS_TIMEOUT_MS },
+			{ cwd: consumer, encoding: "utf8", timeout: CONSUMER_IMPORT_TIMEOUT_MS },
 		);
 		assert.equal(
 			imported.status,
 			0,
-			`consumer import failed for ${basename(tarball)} (timeout=${PACKAGE_SUBPROCESS_TIMEOUT_MS}ms; status=${String(imported.status)}; signal=${String(imported.signal)}; error=${imported.error?.message ?? "none"})\nstdout:\n${imported.stdout}\nstderr:\n${imported.stderr}`,
+			`consumer import failed for ${basename(tarball)} (timeout=${CONSUMER_IMPORT_TIMEOUT_MS}ms; status=${String(imported.status)}; signal=${String(imported.signal)}; error=${imported.error?.message ?? "none"})\nstdout:\n${imported.stdout}\nstderr:\n${imported.stderr}`,
 		);
 	} finally {
 		await rm(temporaryRoot, { recursive: true, force: true });

--- a/tests/package-publish.test.ts
+++ b/tests/package-publish.test.ts
@@ -4,16 +4,68 @@ import { existsSync } from "node:fs";
 import { cp, mkdtemp, mkdir, readFile, readdir, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { basename, join, resolve } from "node:path";
-import { spawnSync } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 
 const projectRoot = resolve(import.meta.dirname, "..");
 const PACK_TIMEOUT_MS = 45_000;
 const OFFLINE_INSTALL_TIMEOUT_MS = 45_000;
 const CONSUMER_IMPORT_TIMEOUT_MS = 15_000;
+const PI_PACKAGE_RESPONSE_TIMEOUT_MS = 25_000;
+const PI_CHILD_STDIN_GRACE_MS = 1_000;
+const PI_CHILD_TERM_GRACE_MS = 2_000;
+const PI_CHILD_KILL_GRACE_MS = 2_000;
+const PI_PACKAGE_LOAD_TIMEOUT_MS =
+	PI_PACKAGE_RESPONSE_TIMEOUT_MS + PI_CHILD_STDIN_GRACE_MS + PI_CHILD_TERM_GRACE_MS + PI_CHILD_KILL_GRACE_MS;
 const SETUP_CLEANUP_MARGIN_MS = 30_000;
-const PACKAGE_TEST_TIMEOUT_MS = 150_000;
+const PACKAGE_TEST_TIMEOUT_MS = 180_000;
 const BUDGETED_TEST_DURATION_MS =
-	PACK_TIMEOUT_MS + OFFLINE_INSTALL_TIMEOUT_MS + CONSUMER_IMPORT_TIMEOUT_MS + SETUP_CLEANUP_MARGIN_MS;
+	PACK_TIMEOUT_MS +
+	OFFLINE_INSTALL_TIMEOUT_MS +
+	CONSUMER_IMPORT_TIMEOUT_MS +
+	PI_PACKAGE_LOAD_TIMEOUT_MS +
+	SETUP_CLEANUP_MARGIN_MS;
+const EXPECTED_EXTENSION_COMMANDS = [
+	"team",
+	"team-copy",
+	"team-enable",
+	"team-init",
+	"team-result",
+	"team-steer",
+	"team-stop",
+];
+
+function subprocessEnv(overrides: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
+	const env = Object.fromEntries(
+		Object.entries(process.env).filter(([key]) => key.toLowerCase() !== "npm_config_dry_run"),
+	);
+	return { ...env, npm_config_dry_run: "false", ...overrides };
+}
+
+function isolatedPiEnv(isolationRoot: string): NodeJS.ProcessEnv {
+	const configKeys = new Set([
+		"HOME",
+		"USERPROFILE",
+		"APPDATA",
+		"LOCALAPPDATA",
+		"XDG_CONFIG_HOME",
+		"XDG_DATA_HOME",
+	]);
+	const inheritedRuntimeEnv = Object.fromEntries(
+		Object.entries(subprocessEnv()).filter(([key]) => !key.toUpperCase().startsWith("PI_") && !configKeys.has(key.toUpperCase())),
+	);
+	return {
+		...inheritedRuntimeEnv,
+		PI_CODING_AGENT_DIR: join(isolationRoot, "pi-agent"),
+		PI_OFFLINE: "1",
+		HOME: join(isolationRoot, "home"),
+		USERPROFILE: join(isolationRoot, "user-profile"),
+		APPDATA: join(isolationRoot, "app-data"),
+		LOCALAPPDATA: join(isolationRoot, "local-app-data"),
+		XDG_CONFIG_HOME: join(isolationRoot, "xdg-config"),
+		XDG_DATA_HOME: join(isolationRoot, "xdg-data"),
+		NO_UPDATE_NOTIFIER: "1",
+	};
+}
 
 function runNpm(args: string[], cwd: string, timeoutMs: number) {
 	const npmCli = process.env.npm_execpath;
@@ -22,7 +74,7 @@ function runNpm(args: string[], cwd: string, timeoutMs: number) {
 	const result = spawnSync(command, commandArgs, {
 		cwd,
 		encoding: "utf8",
-		env: { ...process.env, NO_UPDATE_NOTIFIER: "1" },
+		env: subprocessEnv({ NO_UPDATE_NOTIFIER: "1" }),
 		timeout: timeoutMs,
 	});
 	assert.equal(
@@ -33,10 +85,156 @@ function runNpm(args: string[], cwd: string, timeoutMs: number) {
 	return result;
 }
 
+type RpcResponse = {
+	id?: string;
+	type?: string;
+	command?: string;
+	success?: boolean;
+	data?: {
+		commands?: Array<{
+			name?: string;
+			source?: string;
+			sourceInfo?: { path?: string; source?: string; origin?: string };
+		}>;
+	};
+	error?: string;
+};
+
+async function loadPackageCommandsWithPi(consumer: string, isolationRoot: string): Promise<RpcResponse> {
+	const piCli = join(consumer, "node_modules", "@earendil-works", "pi-coding-agent", "dist", "cli.js");
+	const child = spawn(
+		process.execPath,
+		[
+			piCli,
+			"--mode",
+			"rpc",
+			"--no-session",
+			"--offline",
+			"--approve",
+			"--no-skills",
+			"--no-prompt-templates",
+			"--no-themes",
+			"--no-context-files",
+			"--no-builtin-tools",
+		],
+		{
+			cwd: consumer,
+			env: isolatedPiEnv(isolationRoot),
+			stdio: ["pipe", "pipe", "pipe"],
+		},
+	);
+
+	return new Promise((resolveResponse, reject) => {
+		let stdout = "";
+		let stdoutBuffer = "";
+		let stderr = "";
+		let response: RpcResponse | undefined;
+		let teardownError: Error | undefined;
+		let teardownStarted = false;
+		let settled = false;
+		const teardownTimers = new Set<NodeJS.Timeout>();
+
+		const schedule = (callback: () => void, delayMs: number) => {
+			const timer = setTimeout(() => {
+				teardownTimers.delete(timer);
+				callback();
+			}, delayMs);
+			teardownTimers.add(timer);
+		};
+		const clearTeardownTimers = () => {
+			for (const timer of teardownTimers) clearTimeout(timer);
+			teardownTimers.clear();
+		};
+		const finish = (error?: Error) => {
+			if (settled) return;
+			settled = true;
+			clearTeardownTimers();
+			clearTimeout(responseTimer);
+			child.stdin.destroy();
+			child.stdout.destroy();
+			child.stderr.destroy();
+			if (error) reject(error);
+			else resolveResponse(response!);
+		};
+		const beginTeardown = (error?: Error) => {
+			if (teardownStarted) return;
+			teardownStarted = true;
+			teardownError = error;
+			child.stdin.end();
+
+			schedule(() => {
+				// On Windows, Node maps kill() to TerminateProcess; POSIX gets a
+				// graceful SIGTERM before the final uncatchable escalation.
+				child.kill(process.platform === "win32" ? undefined : "SIGTERM");
+				schedule(() => child.kill("SIGKILL"), PI_CHILD_TERM_GRACE_MS);
+			}, PI_CHILD_STDIN_GRACE_MS);
+			schedule(() => {
+				const teardownMessage = `Pi child did not exit within the ${PI_CHILD_STDIN_GRACE_MS + PI_CHILD_TERM_GRACE_MS + PI_CHILD_KILL_GRACE_MS}ms teardown deadline`;
+				finish(
+					new Error(
+						`${teardownError ? `${teardownError.message}\n` : ""}${teardownMessage}\nstdout:\n${stdout}\nstderr:\n${stderr}`,
+					),
+				);
+			}, PI_CHILD_STDIN_GRACE_MS + PI_CHILD_TERM_GRACE_MS + PI_CHILD_KILL_GRACE_MS);
+		};
+		const responseTimer = setTimeout(() => {
+			beginTeardown(
+				new Error(
+					`Pi package response timed out after ${PI_PACKAGE_RESPONSE_TIMEOUT_MS}ms\nstdout:\n${stdout}\nstderr:\n${stderr}`,
+				),
+			);
+		}, PI_PACKAGE_RESPONSE_TIMEOUT_MS);
+
+		child.stderr.setEncoding("utf8");
+		child.stderr.on("data", (chunk: string) => {
+			stderr += chunk;
+		});
+		child.stdout.setEncoding("utf8");
+		child.stdout.on("data", (chunk: string) => {
+			stdout += chunk;
+			stdoutBuffer += chunk;
+			while (true) {
+				const newlineIndex = stdoutBuffer.indexOf("\n");
+				if (newlineIndex === -1) break;
+				const line = stdoutBuffer.slice(0, newlineIndex).replace(/\r$/, "");
+				stdoutBuffer = stdoutBuffer.slice(newlineIndex + 1);
+				if (!line.trim()) continue;
+				let event: RpcResponse;
+				try {
+					event = JSON.parse(line) as RpcResponse;
+				} catch {
+					continue;
+				}
+				if (event.type === "response" && event.id === "package-commands" && !teardownStarted) {
+					response = event;
+					beginTeardown();
+				}
+			}
+		});
+		child.on("error", (error) => beginTeardown(error));
+		child.stdin.on("error", (error) => {
+			if (!teardownStarted) beginTeardown(error);
+		});
+		child.on("close", (code, signal) => {
+			if (settled) return;
+			if (teardownStarted) {
+				finish(teardownError);
+				return;
+			}
+			finish(
+				new Error(
+					`Pi exited before reporting package commands (status=${String(code)}; signal=${String(signal)})\nstdout:\n${stdout}\nstderr:\n${stderr}`,
+				),
+			);
+		});
+		child.stdin.write(`${JSON.stringify({ id: "package-commands", type: "get_commands" })}\n`);
+	});
+}
+
 test("the package publish timeout covers every subprocess budget and filesystem cleanup", () => {
 	assert.ok(
 		PACKAGE_TEST_TIMEOUT_MS > BUDGETED_TEST_DURATION_MS,
-		`outer timeout (${PACKAGE_TEST_TIMEOUT_MS}ms) must exceed pack (${PACK_TIMEOUT_MS}ms) + offline install (${OFFLINE_INSTALL_TIMEOUT_MS}ms) + consumer import (${CONSUMER_IMPORT_TIMEOUT_MS}ms) + setup/cleanup (${SETUP_CLEANUP_MARGIN_MS}ms)`,
+		`outer timeout (${PACKAGE_TEST_TIMEOUT_MS}ms) must exceed pack (${PACK_TIMEOUT_MS}ms) + offline install (${OFFLINE_INSTALL_TIMEOUT_MS}ms) + consumer import (${CONSUMER_IMPORT_TIMEOUT_MS}ms) + Pi package load (${PI_PACKAGE_LOAD_TIMEOUT_MS}ms) + setup/cleanup (${SETUP_CLEANUP_MARGIN_MS}ms)`,
 	);
 });
 
@@ -131,6 +329,44 @@ test("a clean publish artifact installs and imports in an offline consumer", { t
 			0,
 			`consumer import failed for ${basename(tarball)} (timeout=${CONSUMER_IMPORT_TIMEOUT_MS}ms; status=${String(imported.status)}; signal=${String(imported.signal)}; error=${imported.error?.message ?? "none"})\nstdout:\n${imported.stdout}\nstderr:\n${imported.stderr}`,
 		);
+
+		const piIsolationRoot = join(temporaryRoot, "pi-isolation");
+		await Promise.all([
+			...[
+				"pi-agent",
+				"home",
+				"user-profile",
+				"app-data",
+				"local-app-data",
+				"xdg-config",
+				"xdg-data",
+			].map((directory) => mkdir(join(piIsolationRoot, directory), { recursive: true })),
+			mkdir(join(consumer, ".pi")),
+		]);
+		await writeFile(
+			join(consumer, ".pi", "settings.json"),
+			JSON.stringify({ packages: [installedPackage] }),
+		);
+		const piResponse = await loadPackageCommandsWithPi(consumer, piIsolationRoot);
+		assert.equal(piResponse.success, true, piResponse.error ?? "Pi get_commands failed");
+		const extensionCommands = (piResponse.data?.commands ?? [])
+			.filter((command) => command.source === "extension")
+			.sort((left, right) => (left.name ?? "").localeCompare(right.name ?? ""));
+		assert.deepEqual(
+			extensionCommands.map((command) => command.name),
+			EXPECTED_EXTENSION_COMMANDS,
+			"Pi must execute the packed compiled factory and register its deterministic command surface",
+		);
+		const compiledEntry = join(installedPackage, "dist", "extensions", "index.js");
+		for (const command of extensionCommands) {
+			assert.equal(
+				command.sourceInfo?.path,
+				compiledEntry,
+				`${command.name} must originate from the packed compiled entrypoint`,
+			);
+			assert.equal(command.sourceInfo?.source, installedPackage, `${command.name} must be loaded from the installed tarball`);
+			assert.equal(command.sourceInfo?.origin, "package", `${command.name} must be discovered as a Pi package resource`);
+		}
 	} finally {
 		await rm(temporaryRoot, { recursive: true, force: true });
 	}

--- a/tests/runtime/pi-version.test.ts
+++ b/tests/runtime/pi-version.test.ts
@@ -6,7 +6,9 @@ import { tmpdir } from "node:os";
 import { delimiter, join } from "node:path";
 import {
 	HOST_PI_VERSION,
+	MAX_COMPLETED_PROBE_CACHE_ENTRIES,
 	SUCCESSFUL_PROBE_CACHE_TTL_MS,
+	_testing as versionTesting,
 	buildPiVersionProbeCacheKey,
 	clearPiVersionProbeCache,
 	comparePiVersions,
@@ -64,6 +66,37 @@ test("rejects old, malformed, and missing worker versions with actionable diagno
 	}
 });
 
+test("redacts token-bearing wrapper arguments from every failure diagnostic", async () => {
+	const secret = "wrapper-token-that-must-stay-private";
+	const cliEntry = "/tmp/private-wrapper-cli.js";
+	const options = {
+		command: "custom-pi",
+		baseArgs: ["--token", secret, cliEntry, "--mode", "rpc"],
+		cwd: "/tmp",
+	};
+	const failed = await probeWorkerPiVersion(
+		options,
+		runner({
+			code: null,
+			error: new Error(`spawn failed for --token ${secret} ${cliEntry}`),
+		}),
+	);
+	assert.deepEqual(failed.versionArgs, ["--token", secret, cliEntry, "--version"]);
+	assert.doesNotMatch(failed.message ?? "", /argv/);
+	assert.doesNotMatch(failed.message ?? "", /--token/);
+	assert.doesNotMatch(failed.message ?? "", new RegExp(secret));
+	assert.doesNotMatch(failed.message ?? "", /private-wrapper-cli/);
+
+	const unparseable = await probeWorkerPiVersion(
+		options,
+		runner({ stdout: `not a version: --token ${secret} ${cliEntry}` }),
+	);
+	assert.doesNotMatch(unparseable.message ?? "", /--token/);
+	assert.doesNotMatch(unparseable.message ?? "", new RegExp(secret));
+	assert.doesNotMatch(unparseable.message ?? "", /private-wrapper-cli/);
+	assert.deepEqual(versionTesting.snapshotProbeCache(), []);
+});
+
 test("reports supported host/worker mismatch but not an exact match", async () => {
 	const exact = await probeWorkerPiVersion({ command: "exact", cwd: "/tmp" }, runner({ stdout: HOST_PI_VERSION }));
 	const mismatch = await probeWorkerPiVersion({ command: "newer", cwd: "/tmp" }, runner({ stdout: "0.81.0" }));
@@ -86,7 +119,10 @@ test("caches probes and coalesces concurrent first probes by command", async () 
 	const second = probeWorkerPiVersion(options, run);
 	assert.equal(calls, 1);
 	release();
-	assert.strictEqual(await first, await second);
+	const firstResult = await first;
+	const secondResult = await second;
+	assert.deepEqual(firstResult, secondResult);
+	assert.notStrictEqual(firstResult, secondResult);
 	await probeWorkerPiVersion(options, run);
 	assert.equal(calls, 1);
 });
@@ -106,6 +142,72 @@ test("expires successful cache entries while continuing to coalesce pending prob
 	now += 1;
 	assert.equal((await probeWorkerPiVersion(options, run)).workerVersion, "0.81.0");
 	assert.equal(calls, 2);
+});
+
+test("purges expired completed entries when an unrelated command is probed", async (t) => {
+	let now = 10_000;
+	t.mock.method(Date, "now", () => now);
+	let calls = 0;
+	const run: RunPiVersionCommand = async () => {
+		calls += 1;
+		return { stdout: "0.80.6", stderr: "", code: 0 };
+	};
+	await probeWorkerPiVersion({ command: "/tmp/expired-first-pi", cwd: "/tmp" }, run);
+	await probeWorkerPiVersion({ command: "/tmp/expired-second-pi", cwd: "/tmp" }, run);
+	assert.equal(versionTesting.snapshotProbeCache().length, 2);
+
+	now += SUCCESSFUL_PROBE_CACHE_TTL_MS;
+	await probeWorkerPiVersion({ command: "/tmp/unrelated-pi", cwd: "/tmp" }, run);
+	assert.equal(versionTesting.snapshotProbeCache().length, 1);
+	assert.equal(calls, 3);
+});
+
+test("bounds completed cache entries by evicting the oldest successful probe", async (t) => {
+	let now = 20_000;
+	t.mock.method(Date, "now", () => now);
+	let calls = 0;
+	const run: RunPiVersionCommand = async () => {
+		calls += 1;
+		return { stdout: "0.80.6", stderr: "", code: 0 };
+	};
+	for (let index = 0; index <= MAX_COMPLETED_PROBE_CACHE_ENTRIES; index += 1) {
+		await probeWorkerPiVersion({ command: `/tmp/capacity-pi-${index}`, cwd: "/tmp" }, run);
+		now += 1;
+	}
+	assert.equal(versionTesting.snapshotProbeCache().length, MAX_COMPLETED_PROBE_CACHE_ENTRIES);
+	assert.equal(calls, MAX_COMPLETED_PROBE_CACHE_ENTRIES + 1);
+
+	await probeWorkerPiVersion({ command: "/tmp/capacity-pi-0", cwd: "/tmp" }, run);
+	assert.equal(calls, MAX_COMPLETED_PROBE_CACHE_ENTRIES + 2);
+	assert.equal(versionTesting.snapshotProbeCache().length, MAX_COMPLETED_PROBE_CACHE_ENTRIES);
+});
+
+test("stores only sanitized compatibility data after a successful wrapper probe", async () => {
+	const secret = "cached-wrapper-token-that-must-stay-private";
+	const cliEntry = "/tmp/cached-private-wrapper-cli.js";
+	const options = {
+		command: "cached-wrapper-pi",
+		baseArgs: ["--token", secret, cliEntry, "--mode", "rpc"],
+		cwd: "/tmp",
+	};
+	let calls = 0;
+	const run: RunPiVersionCommand = async () => {
+		calls += 1;
+		return { stdout: "0.80.6", stderr: "", code: 0 };
+	};
+	const expectedArgs = ["--token", secret, cliEntry, "--version"];
+	const first = await probeWorkerPiVersion(options, run);
+	assert.deepEqual(first.versionArgs, expectedArgs);
+	const cacheSnapshot = JSON.stringify(versionTesting.snapshotProbeCache());
+	assert.doesNotMatch(cacheSnapshot, /--token/);
+	assert.doesNotMatch(cacheSnapshot, new RegExp(secret));
+	assert.doesNotMatch(cacheSnapshot, /cached-private-wrapper-cli/);
+
+	first.versionArgs.fill("caller mutation");
+	const second = await probeWorkerPiVersion(options, run);
+	assert.deepEqual(second.versionArgs, expectedArgs);
+	assert.notStrictEqual(first.versionArgs, second.versionArgs);
+	assert.equal(calls, 1);
 });
 
 test("does not retain raw environment or CLI credential values in cache keys", () => {

--- a/tests/runtime/pi-version.test.ts
+++ b/tests/runtime/pi-version.test.ts
@@ -127,6 +127,149 @@ test("caches probes and coalesces concurrent first probes by command", async () 
 	assert.equal(calls, 1);
 });
 
+test("coalesces the same resolved command and CLI prefix across cwd and unrelated environment changes", async () => {
+	const root = await mkdtemp(join(tmpdir(), "pi-version-identity-"));
+	const executable = join(root, "pi");
+	await writeFile(executable, "shared executable");
+	let calls = 0;
+	let release!: () => void;
+	const blocked = new Promise<void>((resolve) => { release = resolve; });
+	const run: RunPiVersionCommand = async () => {
+		calls += 1;
+		await blocked;
+		return { stdout: "0.80.6", stderr: "", code: 0 };
+	};
+	const baseArgs = ["/shared/pi-cli.js", "--mode", "rpc", "--no-session"];
+	try {
+		const first = probeWorkerPiVersion({
+			command: executable,
+			baseArgs,
+			cwd: root,
+			env: { PATH: "/first/path", UNRELATED: "first" },
+		}, run);
+		const second = probeWorkerPiVersion({
+			command: executable,
+			baseArgs,
+			cwd: tmpdir(),
+			env: { PATH: "/second/path", UNRELATED: "second" },
+		}, run);
+		assert.equal(calls, 1);
+		release();
+		assert.equal((await first).workerVersion, "0.80.6");
+		assert.equal((await second).workerVersion, "0.80.6");
+		assert.equal(calls, 1);
+	} finally {
+		release();
+		await rm(root, { recursive: true, force: true });
+	}
+});
+
+test("separates identical relative CLI prefixes that resolve under different cwd values", async () => {
+	const root = await mkdtemp(join(tmpdir(), "pi-version-relative-prefix-"));
+	const firstCwd = join(root, "first");
+	const secondCwd = join(root, "second");
+	const relativeCli = join("relative", "pi-cli.js");
+	await mkdir(join(firstCwd, "relative"), { recursive: true });
+	await mkdir(join(secondCwd, "relative"), { recursive: true });
+	await writeFile(join(firstCwd, relativeCli), "supported CLI");
+	await writeFile(join(secondCwd, relativeCli), "unsupported CLI");
+	let calls = 0;
+	const run: RunPiVersionCommand = async ({ cwd }) => {
+		calls += 1;
+		return { stdout: cwd === firstCwd ? "0.80.7" : "0.80.5", stderr: "", code: 0 };
+	};
+	const baseArgs = [relativeCli, "--mode", "rpc", "--no-session"];
+	try {
+		const supported = await probeWorkerPiVersion({ command: process.execPath, baseArgs, cwd: firstCwd }, run);
+		const unsupported = await probeWorkerPiVersion({ command: process.execPath, baseArgs, cwd: secondCwd }, run);
+		assert.equal(supported.workerVersion, "0.80.7");
+		assert.equal(supported.supported, true);
+		assert.equal(unsupported.workerVersion, "0.80.5");
+		assert.equal(unsupported.supported, false);
+		assert.equal(calls, 2, "different resolved relative entrypoints must not share a probe result");
+	} finally {
+		await rm(root, { recursive: true, force: true });
+	}
+});
+
+test("relative inline Node resources are cwd-sensitive while absolute prefixes remain canonical", () => {
+	const command = process.execPath;
+	const cli = "/shared/pi-cli.js";
+	const firstRelative = buildPiVersionProbeCacheKey(command, ["--env-file=worker.env", cli, "--version"], "/first");
+	const secondRelative = buildPiVersionProbeCacheKey(command, ["--env-file=worker.env", cli, "--version"], "/second");
+	const firstAbsolute = buildPiVersionProbeCacheKey(command, ["--env-file=/shared/worker.env", cli, "--version"], "/first");
+	const secondAbsolute = buildPiVersionProbeCacheKey(command, ["--env-file=/shared/worker.env", cli, "--version"], "/second");
+	assert.notEqual(firstRelative, secondRelative);
+	assert.equal(firstAbsolute, secondAbsolute);
+});
+
+test("canonicalizes dash-prefixed positional CLI entries after the option terminator", async () => {
+	const root = await mkdtemp(join(tmpdir(), "pi-version-option-terminator-"));
+	const firstCwd = join(root, "first");
+	const secondCwd = join(root, "second");
+	await mkdir(firstCwd);
+	await mkdir(secondCwd);
+	await writeFile(join(firstCwd, "-pi-cli.js"), "supported CLI");
+	await writeFile(join(secondCwd, "-pi-cli.js"), "unsupported CLI");
+	let calls = 0;
+	const run: RunPiVersionCommand = async ({ cwd }) => {
+		calls += 1;
+		return { stdout: cwd === firstCwd ? "0.80.7" : "0.80.5", stderr: "", code: 0 };
+	};
+	const baseArgs = ["--", "-pi-cli.js", "--mode", "rpc", "--no-session"];
+	try {
+		assert.equal((await probeWorkerPiVersion({ command: process.execPath, baseArgs, cwd: firstCwd }, run)).supported, true);
+		assert.equal((await probeWorkerPiVersion({ command: process.execPath, baseArgs, cwd: secondCwd }, run)).supported, false);
+		assert.equal(calls, 2, "dash-prefixed positional entrypoints in different cwd roots must not share a probe");
+	} finally {
+		await rm(root, { recursive: true, force: true });
+	}
+});
+
+test("classifies Windows drive and UNC resources before generic URL schemes", () => {
+	const command = process.execPath;
+	const suffix = ["--version"];
+	const driveAbsolute = ["C:\\pi\\cli.js", ...suffix];
+	const driveRelative = ["C:pi\\cli.js", ...suffix];
+	const unc = ["\\\\server\\share\\pi-cli.js", ...suffix];
+	const url = ["file:///shared/pi-cli.js", ...suffix];
+
+	assert.equal(
+		buildPiVersionProbeCacheKey(command, driveAbsolute, "/first", {}),
+		buildPiVersionProbeCacheKey(command, driveAbsolute, "/second", {}),
+		"drive-absolute resources are canonical across cwd even on non-Windows test hosts",
+	);
+	assert.notEqual(
+		buildPiVersionProbeCacheKey(command, driveRelative, "/first", {}),
+		buildPiVersionProbeCacheKey(command, driveRelative, "/second", {}),
+		"drive-relative resources must retain cwd identity rather than being mistaken for URLs",
+	);
+	assert.equal(
+		buildPiVersionProbeCacheKey(command, unc, "/first", {}),
+		buildPiVersionProbeCacheKey(command, unc, "/second", {}),
+	);
+	assert.equal(
+		buildPiVersionProbeCacheKey(command, url, "/first", {}),
+		buildPiVersionProbeCacheKey(command, url, "/second", {}),
+	);
+});
+
+test("invalidates a cached prefix identity when a native absolute CLI entrypoint is replaced", async () => {
+	const root = await mkdtemp(join(tmpdir(), "pi-version-prefix-replace-"));
+	const cli = join(root, "pi-cli.js");
+	const replacement = join(root, "pi-cli-new.js");
+	await writeFile(cli, "first CLI");
+	try {
+		const first = buildPiVersionProbeCacheKey(process.execPath, [cli, "--version"], root);
+		await writeFile(replacement, "replacement CLI with different size");
+		await rename(replacement, cli);
+		const second = buildPiVersionProbeCacheKey(process.execPath, [cli, "--version"], root);
+		assert.notEqual(first, second);
+	} finally {
+		await rm(root, { recursive: true, force: true });
+	}
+});
+
 test("expires successful cache entries while continuing to coalesce pending probes", async (t) => {
 	let now = 1_000;
 	t.mock.method(Date, "now", () => now);
@@ -210,7 +353,7 @@ test("stores only sanitized compatibility data after a successful wrapper probe"
 	assert.equal(calls, 1);
 });
 
-test("does not retain raw environment or CLI credential values in cache keys", () => {
+test("does not retain or key on unrelated environment values", () => {
 	const secret = "credential-value-that-must-not-be-retained";
 	const first = buildPiVersionProbeCacheKey("missing-pi", ["--token", secret, "--version"], "/tmp", {
 		PATH: "/credential/path",
@@ -221,7 +364,7 @@ test("does not retain raw environment or CLI credential values in cache keys", (
 		API_TOKEN: `${secret}-changed`,
 	});
 	assert.doesNotMatch(first, /credential-value|API_TOKEN|credential\/path/);
-	assert.notEqual(first, second);
+	assert.equal(first, second);
 });
 
 test("does not expose a sensitive resolved PATH directory in cache keys", async () => {

--- a/tests/runtime/rpc-client.test.ts
+++ b/tests/runtime/rpc-client.test.ts
@@ -41,3 +41,21 @@ test("RpcClient correlates requests and responses", async () => {
 
 	client.dispose();
 });
+
+test("RpcClient aborts in-flight stats requests and removes every pending deferred", async () => {
+	const stdin = new PassThrough();
+	const stdout = new PassThrough();
+	const client = new RpcClient({ stdin, stdout });
+	const pending = (client as unknown as { pending: Map<string, unknown> }).pending;
+
+	for (let index = 0; index < 25; index += 1) {
+		const controller = new AbortController();
+		const request = client.getSessionStats(controller.signal);
+		assert.equal(pending.size, 1);
+		controller.abort();
+		await assert.rejects(request, /RPC command aborted: get_session_stats/);
+		assert.equal(pending.size, 0, `cancelled request ${index + 1} must not remain pending`);
+	}
+
+	client.dispose();
+});

--- a/tests/runtime/test-helpers.ts
+++ b/tests/runtime/test-helpers.ts
@@ -16,6 +16,7 @@ export interface MockTransportOptions {
 	autoCompletePrompt?: boolean;
 	sessionStats?: Record<string, unknown> | (() => Record<string, unknown>);
 	rejectSessionStats?: string;
+	hangCommands?: string[];
 }
 
 export class MockWorkerTransport extends EventEmitter implements WorkerTransport {
@@ -98,6 +99,7 @@ export class MockWorkerTransport extends EventEmitter implements WorkerTransport
 			const command = JSON.parse(line) as MockCommand;
 			this.commands.push(command);
 			this.options.onCommand?.(command);
+			if (this.options.hangCommands?.includes(command.type)) continue;
 			this.handleCommand(command);
 		}
 	}

--- a/tests/runtime/worker-manager.test.ts
+++ b/tests/runtime/worker-manager.test.ts
@@ -294,6 +294,101 @@ test("abort, RPC parse error, exit, and prompt rejection take precedence over la
 	assert.equal(rejectEvents.filter((type) => type === "worker_idle").length, 0);
 });
 
+test("abort ingests data and authoritative usage emitted before acknowledgement without resurrecting lifecycle", async () => {
+	let transport!: MockWorkerTransport;
+	transport = new MockWorkerTransport({
+		autoCompletePrompt: false,
+		onCommand(command) {
+			if (command.type !== "abort") return;
+			transport.writeEvent({ type: "agent_settled" });
+			transport.writeEvent({
+				type: "message_update",
+				assistantMessageEvent: { type: "text_delta", delta: "late abort text" },
+			});
+			transport.writeEvent({
+				type: "tool_execution_end",
+				toolCallId: "abort-tool",
+				toolName: "read",
+				result: { content: [{ type: "text", text: "late tool output" }] },
+				isError: false,
+			});
+			transport.writeEvent({
+				type: "message_end",
+				message: {
+					role: "assistant",
+					content: [{
+						type: "text",
+						text: "<final_answer>\nheadline: abort data retained\nrelay_question: should this aborted worker restart?\nassumption: no\n</final_answer>",
+					}],
+					usage: {
+						input: 31,
+						output: 17,
+						cacheRead: 11,
+						cacheWrite: 5,
+						totalTokens: 64,
+						cost: { total: 0.123456789 },
+					},
+				},
+			});
+			transport.writeEvent({ type: "agent_end", messages: [] });
+		},
+	});
+	const manager = await launchRuntimeTestWorker("worker-abort-data", transport);
+	await manager.promptWorker("worker-abort-data", "retain abort race output");
+	await waitForMicrotasks();
+	transport.writeEvent({
+		type: "tool_execution_start",
+		toolCallId: "abort-tool",
+		toolName: "read",
+		args: { path: "runtime.log" },
+	});
+	await waitForMicrotasks();
+
+	const observedStatuses: WorkerStatus[] = [];
+	const observedRelayCounts: number[] = [];
+	manager.onEvent((worker) => {
+		observedStatuses.push(worker.state.status);
+		observedRelayCounts.push(worker.state.pendingRelayQuestions.length);
+	});
+	await manager.abortWorker("worker-abort-data");
+	await waitForMicrotasks();
+
+	const state = manager.getWorker("worker-abort-data")?.state;
+	assert.equal(state?.status, "aborted");
+	assert.ok(observedStatuses.length > 0);
+	assert.ok(observedStatuses.every((status) => status === "aborted"), `late events resurrected status: ${observedStatuses.join(", ")}`);
+	assert.ok(observedRelayCounts.every((count) => count === 0), `late abort message raised relays: ${observedRelayCounts.join(", ")}`);
+	assert.deepEqual(state?.pendingRelayQuestions, []);
+	assert.match(state?.finalAnswer ?? "", /abort data retained/);
+	assert.match(state?.finalAnswer ?? "", /should this aborted worker restart/);
+	assert.equal(state?.usage.inputTokens, 31);
+	assert.equal(state?.usage.outputTokens, 17);
+	assert.equal(state?.usage.cacheReadTokens, 11);
+	assert.equal(state?.usage.cacheWriteTokens, 5);
+	assert.equal(state?.usage.contextTokens, 64);
+	assert.equal(state?.usage.costUsd, 0.123456789);
+	assert.ok(manager.getWorkerActivity("worker-abort-data")?.some((event) => event.outputSnippet === "late tool output"));
+});
+
+test("cancelled refreshStats removes the underlying pending RPC request", async () => {
+	const transport = new MockWorkerTransport({ hangCommands: ["get_session_stats"] });
+	const manager = await launchRuntimeTestWorker("worker-cancelled-stats", transport);
+	const runtime = manager as unknown as {
+		workers: Map<string, { client: { pending: Map<string, unknown> } }>;
+	};
+	const pending = runtime.workers.get("worker-cancelled-stats")?.client.pending;
+	assert.ok(pending);
+
+	for (let index = 0; index < 20; index += 1) {
+		const controller = new AbortController();
+		const refresh = manager.refreshStats("worker-cancelled-stats", controller.signal);
+		assert.equal(pending.size, 1);
+		controller.abort();
+		await assert.rejects(refresh, /aborted/i);
+		assert.equal(pending.size, 0, `refresh ${index + 1} leaked a pending RPC deferred`);
+	}
+});
+
 test("extension errors remain diagnostic until agent settlement transitions the worker to idle", async () => {
 	const transport = new MockWorkerTransport({ autoCompletePrompt: false });
 	const manager = await launchRuntimeTestWorker("worker-extension-diagnostic", transport);

--- a/tests/runtime/worker-manager.test.ts
+++ b/tests/runtime/worker-manager.test.ts
@@ -2,8 +2,9 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import { EventEmitter } from "node:events";
 import { PassThrough, Writable } from "node:stream";
-import { WorkerManager } from "../../src/runtime/worker-manager";
-import type { ExitInfo, WorkerProcessHandle, WorkerTransport } from "../../src/runtime/worker-process";
+import { DEFAULT_HANDLE_DISPOSE_TIMEOUT_MS, WorkerManager } from "../../src/runtime/worker-manager";
+import { WORKER_PROCESS_DISPOSE_MAX_MS, type ExitInfo, type WorkerProcessHandle, type WorkerTransport } from "../../src/runtime/worker-process";
+import type { PiVersionProbeResult } from "../../src/runtime/pi-version";
 import { createDefaultTeamState } from "../../src/config";
 import { buildTeamWidgetLines } from "../../src/ui/status-widget";
 import { stripAnsi } from "../../src/ui/theme";
@@ -96,6 +97,41 @@ class FailingLaunchHandle implements WorkerProcessHandle {
 	dispose(): Promise<ExitInfo> {
 		this.kill();
 		return this.exitPromise;
+	}
+}
+
+class InstrumentedWorkerHandle implements WorkerProcessHandle {
+	private readonly inner: MockWorkerHandle;
+	disposeCalls = 0;
+
+	constructor(
+		readonly transport: MockWorkerTransport,
+		private readonly disposeMode: "resolve" | "reject" | "hang" = "resolve",
+	) {
+		this.inner = new MockWorkerHandle(transport);
+	}
+
+	get pid(): number | undefined {
+		return this.inner.pid;
+	}
+
+	get stderrBuffer(): string {
+		return this.inner.stderrBuffer;
+	}
+
+	waitForExit(): Promise<ExitInfo> {
+		return this.inner.waitForExit();
+	}
+
+	kill(signal?: NodeJS.Signals): boolean {
+		return this.inner.kill(signal);
+	}
+
+	dispose(signal?: NodeJS.Signals): Promise<ExitInfo> {
+		this.disposeCalls += 1;
+		if (this.disposeMode === "reject") return Promise.reject(new Error("simulated disposal failure"));
+		if (this.disposeMode === "hang") return Promise.withResolvers<ExitInfo>().promise;
+		return this.inner.dispose(signal);
 	}
 }
 
@@ -1070,6 +1106,180 @@ test("dispose exits live workers while preserving aborted and fatal terminal pre
 	for (const workerId of ["worker-dispose-fatal", "worker-dispose-aborted"]) {
 		assert.equal(terminalEvents.get(workerId)?.filter((type) => type === "worker_idle").length ?? 0, 0);
 	}
+});
+
+test("manager disposal deadline has explicit headroom beyond worker process fallback", () => {
+	assert.ok(
+		DEFAULT_HANDLE_DISPOSE_TIMEOUT_MS > WORKER_PROCESS_DISPOSE_MAX_MS,
+		"manager timeout must not race the worker's Windows taskkill plus exit fallback deadline",
+	);
+});
+
+test("launch cancellation covers pre-reservation, shared-probe, and post-spawn refresh windows", async () => {
+	const alreadyAborted = new AbortController();
+	alreadyAborted.abort();
+	let preflightSpawns = 0;
+	const preflightManager = new WorkerManager(() => {
+		preflightSpawns += 1;
+		return new MockWorkerHandle(new MockWorkerTransport());
+	});
+	await assert.rejects(
+		preflightManager.launchWorker({
+			workerId: "worker-aborted-before-reservation",
+			profileName: "reviewer",
+			task: taskInput("task-aborted-before-reservation", "Already aborted"),
+			cwd: process.cwd(),
+			signal: alreadyAborted.signal,
+		}),
+		/aborted/i,
+	);
+	assert.equal(preflightSpawns, 0);
+	await preflightManager.launchWorker({
+		workerId: "worker-aborted-before-reservation",
+		profileName: "reviewer",
+		task: taskInput("task-after-aborted-reservation", "Reservation was released"),
+		cwd: process.cwd(),
+	});
+	await preflightManager.dispose();
+
+	const probeGate = Promise.withResolvers<PiVersionProbeResult>();
+	const sharedProbe = () => probeGate.promise;
+	const sharedProbeTransports: MockWorkerTransport[] = [];
+	const sharedProbeManager = new WorkerManager(() => {
+		const transport = new MockWorkerTransport();
+		sharedProbeTransports.push(transport);
+		return new MockWorkerHandle(transport);
+	}, sharedProbe);
+	const cancelledProbe = new AbortController();
+	const cancelledLaunch = sharedProbeManager.launchWorker({
+		workerId: "worker-shared-probe-cancelled",
+		profileName: "reviewer",
+		task: taskInput("task-shared-probe-cancelled", "Cancel one probe waiter"),
+		cwd: process.cwd(),
+		signal: cancelledProbe.signal,
+	});
+	const survivingLaunch = sharedProbeManager.launchWorker({
+		workerId: "worker-shared-probe-survives",
+		profileName: "reviewer",
+		task: taskInput("task-shared-probe-survives", "Keep peer waiter"),
+		cwd: process.cwd(),
+	});
+	cancelledProbe.abort();
+	await assert.rejects(cancelledLaunch, /aborted/i);
+	probeGate.resolve({
+		command: "pi",
+		versionArgs: ["--version"],
+		hostVersion: "0.80.6",
+		minimumVersion: "0.80.6",
+		workerVersion: "0.80.6",
+		supported: true,
+		mismatch: false,
+	});
+	await survivingLaunch;
+	assert.equal(sharedProbeTransports.length, 1, "aborting one shared-probe waiter must not cancel its peer");
+	await sharedProbeManager.dispose();
+
+	const refreshTransport = new MockWorkerTransport({ hangCommands: ["get_state"] });
+	const refreshHandle = new InstrumentedWorkerHandle(refreshTransport);
+	let refreshLaunchCount = 0;
+	const refreshManager = new WorkerManager(() => {
+		refreshLaunchCount += 1;
+		return refreshLaunchCount === 1
+			? refreshHandle
+			: new MockWorkerHandle(new MockWorkerTransport());
+	}, undefined, { handleDisposeTimeoutMs: 50 });
+	const pendingRefreshAbort = new AbortController();
+	const pendingRefreshLaunch = refreshManager.launchWorker({
+		workerId: "worker-pending-refresh",
+		profileName: "reviewer",
+		task: taskInput("task-pending-refresh", "Abort pending initial refresh"),
+		cwd: process.cwd(),
+		signal: pendingRefreshAbort.signal,
+	});
+	await waitForMicrotasks();
+	assert.deepEqual(refreshTransport.commands.map((command) => command.type), ["get_state"]);
+	pendingRefreshAbort.abort();
+	await assert.rejects(pendingRefreshLaunch, /aborted/i);
+	assert.equal(refreshHandle.disposeCalls, 1);
+	assert.equal(refreshManager.hasWorker("worker-pending-refresh"), false);
+	assert.equal(refreshTransport.commands.some((command) => command.type === "prompt"), false);
+	await refreshManager.launchWorker({
+		workerId: "worker-pending-refresh",
+		profileName: "reviewer",
+		task: taskInput("task-after-pending-refresh", "Reservation cleanup proof"),
+		cwd: process.cwd(),
+	});
+	await refreshManager.dispose();
+});
+
+test("hung abort and handle disposal settle within configured deadlines", async () => {
+	const transport = new MockWorkerTransport({ hangCommands: ["abort"] });
+	const handle = new InstrumentedWorkerHandle(transport, "hang");
+	const manager = new WorkerManager(() => handle, undefined, {
+		abortTimeoutMs: 10,
+		handleDisposeTimeoutMs: 10,
+	});
+	await manager.launchWorker({
+		workerId: "worker-hung-abort",
+		profileName: "reviewer",
+		task: taskInput("task-hung-abort", "Bound cancellation"),
+		cwd: process.cwd(),
+	});
+	const startedAt = Date.now();
+	await assert.rejects(manager.abortWorker("worker-hung-abort"), /timed out/i);
+	assert.ok(Date.now() - startedAt < 250, "abort and fallback disposal must remain bounded");
+	assert.equal(handle.disposeCalls, 1);
+	assert.equal(manager.getWorker("worker-hung-abort")?.state.status, "error");
+});
+
+test("dispose shares one outcome, cancels pending launches, and aggregates after every worker cleanup", async () => {
+	const pendingProbe = Promise.withResolvers<PiVersionProbeResult>();
+	const handles = [
+		new InstrumentedWorkerHandle(new MockWorkerTransport(), "reject"),
+		new InstrumentedWorkerHandle(new MockWorkerTransport(), "resolve"),
+	];
+	let activeLaunchIndex = 0;
+	const manager = new WorkerManager(
+		() => handles[activeLaunchIndex++]!,
+		(options) => options.command === "pending-pi"
+			? pendingProbe.promise
+			: Promise.resolve({
+				command: options.command ?? "pi",
+				versionArgs: ["--version"],
+				hostVersion: "0.80.6",
+				minimumVersion: "0.80.6",
+				workerVersion: "0.80.6",
+				supported: true,
+				mismatch: false,
+			}),
+		{ handleDisposeTimeoutMs: 25 },
+	);
+	for (const workerId of ["worker-dispose-fails", "worker-dispose-succeeds"]) {
+		await manager.launchWorker({
+			workerId,
+			profileName: "reviewer",
+			task: taskInput(`task-${workerId}`, `Dispose ${workerId}`),
+			cwd: process.cwd(),
+		});
+	}
+	const pendingLaunch = manager.launchWorker({
+		workerId: "worker-dispose-pending-probe",
+		profileName: "reviewer",
+		task: taskInput("task-dispose-pending-probe", "Cancel pending launch"),
+		cwd: process.cwd(),
+		command: "pending-pi",
+	});
+	const firstDispose = manager.dispose();
+	const secondDispose = manager.dispose();
+	assert.equal(firstDispose, secondDispose, "concurrent callers must receive the shared disposal promise");
+	await assert.rejects(firstDispose, (error: unknown) => {
+		assert.ok(error instanceof AggregateError);
+		assert.equal(error.errors.length, 1);
+		return true;
+	});
+	await assert.rejects(pendingLaunch, /aborted|cancelled/i);
+	assert.deepEqual(handles.map((handle) => handle.disposeCalls), [1, 1], "a failed cleanup must not skip peers");
+	assert.equal(activeLaunchIndex, 2, "the cancelled pending probe must never spawn");
 });
 
 test("closeWorker rejects running workers", async () => {

--- a/tests/runtime/worker-process.test.ts
+++ b/tests/runtime/worker-process.test.ts
@@ -1,6 +1,8 @@
 import test from "node:test";
+import { EventEmitter } from "node:events";
 import assert from "node:assert/strict";
-import { buildWorkerProcessArgs, resolveWorkerSpawnImplementation, spawnWorkerProcess } from "../../src/runtime/worker-process";
+import { setTimeout as delay } from "node:timers/promises";
+import { buildWorkerProcessArgs, resolveWorkerSpawnImplementation, spawnWorkerProcess, terminateWindowsWorkerTree } from "../../src/runtime/worker-process";
 import { WorkerManager } from "../../src/runtime/worker-manager";
 import { HOST_PI_VERSION, type ProbeWorkerPiVersion } from "../../src/runtime/pi-version";
 import { MockWorkerHandle, MockWorkerTransport } from "./test-helpers";
@@ -124,6 +126,34 @@ test("resolveWorkerSpawnImplementation uses cross-spawn on Windows", () => {
 	assert.equal(resolveWorkerSpawnImplementation("linux"), "node:child_process");
 });
 
+test("Windows worker termination selects taskkill tree escalation and falls back on failure", async () => {
+	const childSignals: Array<NodeJS.Signals | undefined> = [];
+	const taskkillCalls: Array<{ command: string; args: string[] }> = [];
+	const child = {
+		pid: 4321,
+		kill(signal?: NodeJS.Signals) {
+			childSignals.push(signal);
+			return true;
+		},
+	};
+	const spawnTaskkill = (command: string, args: string[]) => {
+		taskkillCalls.push({ command, args });
+		const killer = new EventEmitter() as EventEmitter & { pid: number; kill(signal?: NodeJS.Signals): boolean };
+		killer.pid = 9999;
+		killer.kill = () => true;
+		queueMicrotask(() => killer.emit("close", 1));
+		return killer;
+	};
+
+	await terminateWindowsWorkerTree(child, spawnTaskkill, 50);
+
+	assert.deepEqual(taskkillCalls, [{
+		command: "taskkill",
+		args: ["/pid", "4321", "/T", "/F"],
+	}]);
+	assert.deepEqual(childSignals, ["SIGKILL"], "failed taskkill must fall back to direct forced termination");
+});
+
 test("WorkerManager rejects an unsupported worker before RPC process launch", async () => {
 	let launches = 0;
 	const manager = new WorkerManager(
@@ -242,4 +272,69 @@ test("spawnWorkerProcess converts child_process spawn errors into waitForExit fa
 	assert.ok(exitInfo.error);
 	assert.match(exitInfo.error.message, /ENOENT|not found/i);
 	assert.match(handle.stderrBuffer, /ENOENT|not found/i);
+});
+
+test("POSIX disposal terminates the worker process group including child and grandchild", {
+	skip: process.platform === "win32",
+	timeout: 5_000,
+}, async () => {
+	const grandchildSource = "process.on('SIGTERM', () => {}); setInterval(() => {}, 1000);";
+	const childSource = [
+		"const { spawn } = require('node:child_process');",
+		"process.on('SIGTERM', () => {});",
+		`const grandchild = spawn(process.execPath, ['-e', ${JSON.stringify(grandchildSource)}], { stdio: 'ignore' });`,
+		"console.log(JSON.stringify({ child: process.pid, grandchild: grandchild.pid }));",
+		"setInterval(() => {}, 1000);",
+	].join("");
+	const workerSource = [
+		"const { spawn } = require('node:child_process');",
+		"process.on('SIGTERM', () => {});",
+		`const child = spawn(process.execPath, ['-e', ${JSON.stringify(childSource)}], { stdio: ['ignore', 'inherit', 'inherit'] });`,
+		"console.log(JSON.stringify({ worker: process.pid, child: child.pid }));",
+		"setInterval(() => {}, 1000);",
+	].join("");
+	const handle = spawnWorkerProcess({
+		cwd: process.cwd(),
+		command: process.execPath,
+		baseArgs: ["-e", workerSource],
+	});
+	let output = "";
+	const pids = new Set<number>();
+	const ready = Promise.withResolvers<void>();
+	handle.transport.stdout.on("data", (chunk) => {
+		output += chunk.toString();
+		for (const line of output.trim().split("\n")) {
+			try {
+				const parsed = JSON.parse(line) as { worker?: number; child?: number; grandchild?: number };
+				for (const pid of [parsed.worker, parsed.child, parsed.grandchild]) {
+					if (typeof pid === "number") pids.add(pid);
+				}
+			} catch {
+				// Wait for a complete JSON line.
+			}
+		}
+		if (pids.size === 3) ready.resolve();
+	});
+	await ready.promise;
+
+	const disposeStartedAt = Date.now();
+	await handle.dispose();
+	assert.ok(Date.now() - disposeStartedAt < 1_500, "tree disposal must settle within its grace and exit bounds");
+
+	const deadline = Date.now() + 1_500;
+	while (Date.now() < deadline) {
+		const survivors = [...pids].filter((pid) => {
+			try {
+				process.kill(pid, 0);
+				return true;
+			} catch {
+				return false;
+			}
+		});
+		if (survivors.length === 0) return;
+		// This integration assertion observes real kernel process reaping; fake
+		// timers cannot advance an OS process from live/zombie to gone.
+		await delay(20);
+	}
+	assert.fail(`process tree survivors after disposal: ${[...pids].join(", ")}`);
 });

--- a/tests/types/persisted-status.test.ts
+++ b/tests/types/persisted-status.test.ts
@@ -1,0 +1,91 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import {
+	PERSISTED_TERMINAL_WORKER_STATUSES,
+	type CompactPersistedWorker,
+	type CompactPersistedWorkerSummary,
+	type PersistedTerminalWorkerStatus,
+} from "../../src/types.js";
+
+type Equal<Left, Right> =
+	(<Value>() => Value extends Left ? 1 : 2) extends
+	(<Value>() => Value extends Right ? 1 : 2) ? true : false;
+type Assert<Condition extends true> = Condition;
+
+type WorkerStatusContract = Assert<Equal<CompactPersistedWorker["status"], PersistedTerminalWorkerStatus>>;
+type SummaryStatusContract = Assert<Equal<CompactPersistedWorkerSummary["status"], PersistedTerminalWorkerStatus>>;
+
+// Keep the assertions live under noUnusedLocals if the test compiler enables it.
+const typeContracts: [WorkerStatusContract, SummaryStatusContract] = [true, true];
+
+// @ts-expect-error compact persisted workers reject runtime-only statuses
+const invalidWorkerStatus: CompactPersistedWorker["status"] = "running";
+// @ts-expect-error compact persisted summaries reject runtime-only statuses
+const invalidSummaryStatus: CompactPersistedWorkerSummary["status"] = "waiting_followup";
+
+void invalidWorkerStatus;
+void invalidSummaryStatus;
+
+const workerFields = {
+	workerId: "w1",
+	profileName: "fixer",
+	startedAt: 1,
+	lastEventAt: 2,
+	usage: { turns: 1, inputTokens: 2, outputTokens: 3, cacheReadTokens: 0, cacheWriteTokens: 0, costUsd: 0 },
+};
+const summaryFields = {
+	headline: "done",
+	readFiles: [],
+	changedFiles: [],
+	risks: [],
+	updatedAt: 2,
+};
+const validIdleWorker: CompactPersistedWorker = {
+	...workerFields,
+	status: "idle",
+	lastSummary: { ...summaryFields, status: "idle" },
+};
+const validErrorWorker: CompactPersistedWorker = {
+	...workerFields,
+	status: "error",
+	lastSummary: { ...summaryFields, status: "error" },
+};
+// @ts-expect-error worker and summary terminal statuses must be the same literal
+const mismatchedTerminalWorker: CompactPersistedWorker = { ...workerFields, status: "idle", lastSummary: { ...summaryFields, status: "error" } };
+
+void validIdleWorker;
+void validErrorWorker;
+void mismatchedTerminalWorker;
+
+test("compact persisted status values match the wire reader terminal allowlist", () => {
+	assert.deepEqual(PERSISTED_TERMINAL_WORKER_STATUSES, ["idle", "completed", "aborted", "error", "exited"]);
+	assert.deepEqual(typeContracts, [true, true]);
+});
+
+test("normal test execution typechecks the compact persisted status contract", () => {
+	const testPath = fileURLToPath(import.meta.url);
+	const tscPath = fileURLToPath(new URL("../../node_modules/typescript/bin/tsc", import.meta.url));
+	const result = spawnSync(process.execPath, [
+		tscPath,
+		"--ignoreConfig",
+		"--noEmit",
+		"--strict",
+		"--skipLibCheck",
+		"--target", "ES2022",
+		"--module", "NodeNext",
+		"--moduleResolution", "NodeNext",
+		"--types", "node",
+		testPath,
+	], {
+		encoding: "utf8",
+		timeout: 15_000,
+		maxBuffer: 1024 * 1024,
+	});
+	assert.equal(
+		result.status,
+		0,
+		`persisted status type contract failed to compile:\n${result.stdout}${result.stderr}`,
+	);
+});


### PR DESCRIPTION
## Bug Description

Cancellation could arrive while a worker was still probing Pi, launching, refreshing reuse stats, or waiting for an RPC response. Those paths did not share one abort contract, so a cancelled delegation could finish late, leave a pending ID reserved, or strand an RPC process when abort acknowledgement failed.

**Expected:** cancellation stops pending work promptly, preserves the correct terminal cause, and completes process cleanup within a bounded time.

**Actual:** asynchronous launch and stats checkpoints could continue after cancellation, and a rejected or hung abort RPC could prevent the control plane from reaching process disposal.

## Root Cause

Abort signals were not propagated through the full control-plane → worker-manager → RPC boundary. Pending launches also lacked a shared deferred cleanup state, and process disposal did not consistently bound every failure path.

## Type of Change

- [x] Bug fix

## Fix Description

- Propagate `AbortSignal` through delegation, reuse stats, worker launch, and RPC session stats.
- Reserve worker IDs before asynchronous Pi preflight and cancel pending launches through a shared abort controller.
- Add cancellable checkpoints before spawn and after awaited preflight/state work.
- Bound abort RPC and process disposal; report combined RPC and shutdown failures without leaving the worker running.
- Dispose RPC requests cleanly and reject pending commands exactly once.
- Preserve terminal state precedence across late state, exit, settlement, and diagnostic events.
- Tighten persisted terminal status unions and live-status normalization.
- Harden executable identity, package publish, persistence restore, and cancellation regression coverage.

## How to Reproduce (Before Fix)

1. Start delegation while Pi version preflight or initial state refresh is pending.
2. Cancel the task, or make the abort RPC reject/hang.
3. Observe late spawn/state work, a reserved worker ID, or cleanup that never reaches process disposal.

## How to Verify (After Fix)

1. Run `npm ci`.
2. Run `npm run check`.
3. Exercise cancellation during version preflight, initial state refresh, reuse stats, and an in-flight RPC command.
4. Force abort-RPC rejection and timeout; confirm the process handle is disposed and terminal status remains authoritative.

Verified on this branch:

- `npm run check`: 537 passed, 0 failed.
- The final tree is byte-for-byte identical to `feat/pi-package-runtime-hardening`.
- Full-tip `npm run build`, `npm run smoke:runtime`, and `npm run smoke:team` completed successfully; both smokes reported clean RPC cleanup.

## Impact Assessment

- **Severity:** High. Failed cancellation can leak a worker process or expose stale lifecycle state.
- **Users affected:** Delegations cancelled during launch, reuse refresh, or in-flight RPC work.
- **Duration:** Pre-existing asynchronous cancellation paths; no introduction date was identified from branch evidence.

## Regression Risk

- Launch cancellation before and after Pi version preflight.
- Duplicate worker IDs while the first launch remains pending.
- Abort RPC rejection, timeout, and process disposal failure.
- Pending RPC command rejection and listener cleanup.
- Terminal status, persisted status, usage, and summary precedence after late events.
- Package/probe contracts that execute child processes in tests.

## Checklist

- [x] Root cause identified and documented above
- [x] Fix addresses the root cause (not just symptoms)
- [x] Added test to prevent regression
- [x] Existing tests pass locally
- [x] Tested the specific reproduction steps
- [x] No new warnings or console errors introduced

## Related Issues

None found in the branch name or commit history.

## Stack

5 of 5. Base: `chore/package-persistence-contracts`. Review after PR 4. This tip matches the original source branch exactly.
