### PR TITLE
Update development dependencies for Pi 0.80.10 compatibility

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Thanks for helping out. This guide covers local setup, the test discipline, and 
 
 ## Local setup
 
-Use Node `>=22.19.0`. Development validation uses exactly Pi `0.80.6`, which is also the supported host and worker minimum. npm and `package-lock.json` are the only supported dependency and lock workflow; do not add or regenerate a Bun lock.
+Use Node `>=22.19.0`. Development validation uses exactly Pi `0.80.10`. The supported host and worker minimum remains Pi `0.80.6`. npm and `package-lock.json` are the only supported dependency and lock workflow; do not add or regenerate a Bun lock.
 
 ```bash
 git clone git@github.com:KristjanPikhof/pi-agents-team.git

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -116,7 +116,7 @@ Workers run through `pi --mode rpc --no-session`. That gives us prompt, steer, f
 The probe keeps a promise cache keyed by the resolved command and any CLI entrypoint prefix. Concurrent first launches share that promise, and later launches reuse the result rather than spawning another version check. This applies to the default and custom worker commands, so injected test launchers must also inject a probe and never fall through to a machine-global `pi`.
 
 Exact host/worker patch equality is not required. A supported worker version that differs from the host emits one non-fatal warning per extension session; an exact match emits none. This is a minimum-version gate, not an upper-bound policy.
-Repository development dependencies and validation use exactly Pi `0.80.6`, the same release as the supported host and worker minimum.
+Repository development dependencies and validation use exactly Pi `0.80.10`. The supported host and worker minimum remains Pi `0.80.6`.
 
 ### Workers launch with reduced discovery
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -2,7 +2,7 @@
 
 ## Quick start
 
-Requires Node `>=22.19.0`. Development validation uses exactly Pi `0.80.6`, which is also the supported host and worker minimum. Use npm and `package-lock.json` as the authoritative dependency and lock workflow.
+Requires Node `>=22.19.0`. Development validation uses exactly Pi `0.80.10`. The supported host and worker minimum remains Pi `0.80.6`. Use npm and `package-lock.json` as the authoritative dependency and lock workflow.
 
 Install dependencies and run the checks:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,20 +1,20 @@
 {
   "name": "pi-agents-team",
-  "version": "2026.7.16",
+  "version": "2026.7.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-agents-team",
-      "version": "2026.7.16",
+      "version": "2026.7.18",
       "license": "MIT",
       "dependencies": {
         "cross-spawn": "^7.0.6",
         "typebox": "^1.0.56"
       },
       "devDependencies": {
-        "@earendil-works/pi-coding-agent": "0.80.6",
-        "@earendil-works/pi-tui": "0.80.6",
+        "@earendil-works/pi-coding-agent": "0.80.10",
+        "@earendil-works/pi-tui": "0.80.10",
         "@types/node": "^25.6.0",
         "tsx": "^4.22.4",
         "typescript": "^6.0.3"
@@ -28,16 +28,16 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent": {
-      "version": "0.80.6",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.80.6.tgz",
-      "integrity": "sha512-vcfD6tOk402isLl3Cm/qbn2O10TvgroMp1+/fEGM24ZdvETFCdOYv5VZ7m59EI5fPsjfSJh+CpQ5bhBrhfOg7g==",
+      "version": "0.80.10",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.80.10.tgz",
+      "integrity": "sha512-aL4apbupCHiVLSXASXvRzH4Q2vmtfrDa+0s909CJuVu/GgGylbDzr7oyF1mPmip5E+VxYYxKWmph4hV04wUcQg==",
       "dev": true,
       "hasShrinkwrap": true,
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-agent-core": "^0.80.6",
-        "@earendil-works/pi-ai": "^0.80.6",
-        "@earendil-works/pi-tui": "^0.80.6",
+        "@earendil-works/pi-agent-core": "^0.80.10",
+        "@earendil-works/pi-ai": "^0.80.10",
+        "@earendil-works/pi-tui": "^0.80.10",
         "@silvia-odwyer/photon-node": "0.3.4",
         "chalk": "5.6.2",
         "cross-spawn": "7.0.6",
@@ -527,12 +527,12 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-agent-core": {
-      "version": "0.80.6",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.80.6.tgz",
+      "version": "0.80.10",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.80.10.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-ai": "^0.80.6",
+        "@earendil-works/pi-ai": "^0.80.10",
         "ignore": "7.0.5",
         "typebox": "1.1.38",
         "yaml": "2.9.0"
@@ -542,8 +542,8 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-ai": {
-      "version": "0.80.6",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.80.6.tgz",
+      "version": "0.80.10",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.80.10.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -567,8 +567,8 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-tui": {
-      "version": "0.80.6",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.80.6.tgz",
+      "version": "0.80.10",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.80.10.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2001,9 +2001,9 @@
       }
     },
     "node_modules/@earendil-works/pi-tui": {
-      "version": "0.80.6",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.80.6.tgz",
-      "integrity": "sha512-bSuzS4EVSqEPj/Qr/p9eqCESfKsGuDNbl77EGci8Iaqqt/C/XCBZL1MjXaxSWW1NsT5afjp/Cb0NTPzOLv/aPA==",
+      "version": "0.80.10",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.80.10.tgz",
+      "integrity": "sha512-c2JO29PbhKPEQ6fgHQKAl0WhwuFqzWfzspMmP+8B5tpDuP+0mvarRbKKg8gq4b+pQx/QX+6aVS4ko7deoyjQjg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-agents-team",
-  "version": "2026.7.16",
+  "version": "2026.7.18",
   "description": "Pi extension that turns one coding session into a multi-agent team with background RPC worker agents.",
   "license": "MIT",
   "type": "module",
@@ -75,8 +75,8 @@
     "@earendil-works/pi-tui": ">=0.80.6"
   },
   "devDependencies": {
-    "@earendil-works/pi-coding-agent": "0.80.6",
-    "@earendil-works/pi-tui": "0.80.6",
+    "@earendil-works/pi-coding-agent": "0.80.10",
+    "@earendil-works/pi-tui": "0.80.10",
     "@types/node": "^25.6.0",
     "tsx": "^4.22.4",
     "typescript": "^6.0.3"

--- a/tests/package-manifest.test.ts
+++ b/tests/package-manifest.test.ts
@@ -37,12 +37,12 @@ test("package manifest exposes only the compiled extension and dist-contained as
 	assert.ok(!packageJson.files?.includes("profiles"), "worker profiles ship under dist only");
 });
 
-test("package manifest pins development checks to the minimum supported Pi release", () => {
+test("package manifest pins development checks to Pi 0.80.10", () => {
 	const testedPiVersions = {
 		codingAgent: packageJson.devDependencies?.["@earendil-works/pi-coding-agent"],
 		tui: packageJson.devDependencies?.["@earendil-works/pi-tui"],
 	};
-	assert.deepEqual(testedPiVersions, { codingAgent: "0.80.6", tui: "0.80.6" });
+	assert.deepEqual(testedPiVersions, { codingAgent: "0.80.10", tui: "0.80.10" });
 	assert.deepEqual(
 		{
 			codingAgent: packageLock.packages?.[""]?.devDependencies?.["@earendil-works/pi-coding-agent"],

--- a/tests/package-publish.test.ts
+++ b/tests/package-publish.test.ts
@@ -238,7 +238,7 @@ test("the package publish timeout covers every subprocess budget and filesystem 
 	);
 });
 
-test("package docs pin Pi 0.80.6 and separate source, compiled, and published validation", async () => {
+test("package docs distinguish Pi 0.80.10 development validation from the 0.80.6 minimum", async () => {
 	const [readme, contributing, operations, architecture] = await Promise.all(
 		["README.md", "CONTRIBUTING.md", "docs/operations.md", "docs/architecture.md"].map((path) =>
 			readFile(join(projectRoot, path), "utf8"),
@@ -252,13 +252,20 @@ test("package docs pin Pi 0.80.6 and separate source, compiled, and published va
 	assert.match(readme, /This checks the source path only; it does not validate the compiled or published package entrypoint\./);
 	assert.match(
 		contributing,
-		/Development validation uses exactly Pi `0\.80\.6`[\s\S]*Do not use `-p "\/team"` as an overlay check/,
+		/Development validation uses exactly Pi `0\.80\.10`\. The supported host and worker minimum remains Pi `0\.80\.6`\.[\s\S]*Do not use `-p "\/team"` as an overlay check/,
 	);
 	assert.match(
 		operations,
 		/Check the source shim during development:[\s\S]*Check the compiled Pi entrypoint:[\s\S]*Check the published package contract/,
 	);
-	assert.match(architecture, /Repository development dependencies and validation use exactly Pi `0\.80\.6`/);
+	assert.match(
+		operations,
+		/Development validation uses exactly Pi `0\.80\.10`\. The supported host and worker minimum remains Pi `0\.80\.6`\./,
+	);
+	assert.match(
+		architecture,
+		/Repository development dependencies and validation use exactly Pi `0\.80\.10`\. The supported host and worker minimum remains Pi `0\.80\.6`\./,
+	);
 });
 
 test("a clean publish artifact installs and imports in an offline consumer", { timeout: PACKAGE_TEST_TIMEOUT_MS }, async () => {


### PR DESCRIPTION
## Description

Update repository development validation to Pi `0.80.10` while retaining Pi `0.80.6` as the supported host, worker, and publication minimum.

This keeps local development aligned with the newer Pi/TUI release without raising the package's public compatibility floor.

## Type of Change

- [ ] New feature
- [ ] Bug fix
- [ ] Refactoring (no functional changes)
- [x] Documentation update
- [x] Infrastructure / CI/CD
- [ ] Performance improvement

## Changes Made

- Pin `@earendil-works/pi-coding-agent` and `@earendil-works/pi-tui` development dependencies to `0.80.10`.
- Advance the package version to `2026.7.18` and refresh `package-lock.json`.
- Preserve the public peer dependency minimum at `>=0.80.6`.
- Update manifest and publication tests to enforce the development/support distinction.
- Update contributor, operations, and architecture documentation.

## How to Test

1. Run `npm run check`.
2. Confirm all 537 tests pass.
3. Verify publication tests continue exercising a Pi `0.80.6` consumer.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-reviewed the code for obvious errors
- [x] Added or updated tests where applicable
- [x] Existing tests pass locally
- [x] Updated documentation if needed
- [x] No new warnings or console errors introduced

## Related Issues

No related issue was found.

## Screenshots

Not applicable.
